### PR TITLE
⚡ Optimize duplicate check in CreateOrderCommandValidator

### DIFF
--- a/tests/MediatorLite.RestApiBenchmarks/Application/Common/CreateOrderCommandValidator.cs
+++ b/tests/MediatorLite.RestApiBenchmarks/Application/Common/CreateOrderCommandValidator.cs
@@ -22,18 +22,23 @@ public sealed class CreateOrderCommandValidator : IAppValidator<CreateOrderComma
             errors.Add("A single order cannot contain more than 50 lines.");
         }
 
-        var duplicatedProductIds = request.Lines
-            .GroupBy(line => line.ProductId)
-            .Where(group => group.Count() > 1)
-            .Select(group => group.Key)
-            .ToArray();
+        var seenProductIds = new HashSet<int>(request.Lines.Count);
+        var duplicatedProductIds = new HashSet<int>();
 
-        if (duplicatedProductIds.Length > 0)
+        foreach (var line in request.Lines)
+        {
+            if (!seenProductIds.Add(line.ProductId))
+            {
+                duplicatedProductIds.Add(line.ProductId);
+            }
+        }
+
+        if (duplicatedProductIds.Count > 0)
         {
             errors.Add("Order lines cannot contain duplicated product IDs.");
         }
 
-        var productIds = request.Lines.Select(line => line.ProductId).Distinct().ToArray();
+        var productIds = seenProductIds.ToArray();
         var products = await _dbContext.Products
             .Where(product => productIds.Contains(product.Id))
             .Select(product => new { product.Id, product.AvailableStock })


### PR DESCRIPTION
💡 **What:** The optimization replaces the LINQ `GroupBy` approach in `CreateOrderCommandValidator` with a `HashSet`-based approach to detect duplicate product IDs and collect distinct IDs in a single pass.

🎯 **Why:** The previous implementation used multiple LINQ operations (`GroupBy`, `Where`, `Select`, `ToArray` followed by `Select`, `Distinct`, `ToArray`), leading to unnecessary allocations and multiple iterations over the `request.Lines` collection.

📊 **Measured Improvement:** 
The new approach reduces complexity from multiple $O(N)$ passes with high constants (due to `GroupBy`) to a single $O(N)$ pass with lower constants. By pre-allocating the `HashSet` capacity, we further minimize re-allocations. Although environmental timeouts prevented capturing final benchmark numbers, this pattern is a well-known optimization for duplicate detection in C# and significantly reduces the allocation footprint in high-throughput scenarios like the REST API benchmarks this code is part of.

---
*PR created automatically by Jules for task [2320494741882573893](https://jules.google.com/task/2320494741882573893) started by @behl1anmol*