### PR TITLE
fix: resolve bug-hunt findings across generator, runtime, tests, and hooks

### DIFF
--- a/.claude/hooks/21-build-gate.csx
+++ b/.claude/hooks/21-build-gate.csx
@@ -8,9 +8,8 @@
 // Slow-path: `dotnet build MediatorLite.sln -c Release --nologo -v q`.
 //
 // Exit semantics:
-//   0   build succeeded (or skipped)
-//   1   build failed — commit blocked
-//   2   dotnet SDK not found — warns but allows commit
+//   0   build succeeded (or skipped, or dotnet SDK not found — warned, commit allowed)
+//   1+  build failed — commit blocked
 
 #load "../lib/ContextDb.csx"
 
@@ -38,7 +37,20 @@ if (!codeTouched)
 }
 
 Console.WriteLine("[hook:21-build-gate] dotnet build MediatorLite.sln -c Release …");
-var (exit, stdout, stderr) = Run("dotnet", "build MediatorLite.sln -c Release --nologo -v q");
+(int exit, string stdout, string stderr) buildResult;
+try
+{
+    buildResult = Run("dotnet", "build MediatorLite.sln -c Release --nologo -v q");
+}
+catch (Exception ex)
+{
+    // Fail open, as documented: a machine without the SDK cannot verify the build, which
+    // is not the same as the build failing. Crashing here used to hard-block the commit.
+    Console.Error.WriteLine($"[hook:21-build-gate] WARN — could not run dotnet ({ex.Message}); allowing commit unverified");
+    ContextDb.LogHookEvent("21-build-gate.csx", "beforeCommit", "warn", sw.ElapsedMilliseconds, new { reason = "dotnet-missing" });
+    return;
+}
+var (exit, stdout, stderr) = buildResult;
 if (exit == 0)
 {
     Console.WriteLine("[hook:21-build-gate] build OK");
@@ -62,10 +74,13 @@ static (int, string, string) Run(string file, string args)
 {
     var psi = new ProcessStartInfo(file, args) { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false };
     using var p = Process.Start(psi)!;
-    var so = p.StandardOutput.ReadToEnd();
-    var se = p.StandardError.ReadToEnd();
+    // Drain both pipes concurrently: reading stdout to EOF while the child blocks on a
+    // full stderr pipe buffer (or vice versa) deadlocks both processes.
+    var so = p.StandardOutput.ReadToEndAsync();
+    var se = p.StandardError.ReadToEndAsync();
+    System.Threading.Tasks.Task.WaitAll(so, se);
     p.WaitForExit();
-    return (p.ExitCode, so, se);
+    return (p.ExitCode, so.Result, se.Result);
 }
 
 static string? RunCapture(string file, string args)

--- a/.claude/hooks/22-lint-gate.csx
+++ b/.claude/hooks/22-lint-gate.csx
@@ -33,7 +33,19 @@ if (!files.Any(f => f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)))
 }
 
 Console.WriteLine("[hook:22-lint-gate] dotnet format --verify-no-changes …");
-var (exit, stdout, stderr) = Run("dotnet", "format MediatorLite.sln --verify-no-changes --no-restore --severity warn");
+(int exit, string stdout, string stderr) formatResult;
+try
+{
+    formatResult = Run("dotnet", "format MediatorLite.sln --verify-no-changes --no-restore --severity warn");
+}
+catch (Exception ex)
+{
+    // Fail open, as documented ("if dotnet format is not installed, warns and allows commit").
+    Console.Error.WriteLine($"[hook:22-lint-gate] WARN — could not run dotnet format ({ex.Message}); allowing commit unverified");
+    ContextDb.LogHookEvent("22-lint-gate.csx", "beforeCommit", "warn", sw.ElapsedMilliseconds, new { reason = "dotnet-missing" });
+    return;
+}
+var (exit, stdout, stderr) = formatResult;
 if (exit == 0)
 {
     Console.WriteLine("[hook:22-lint-gate] format OK");
@@ -58,10 +70,13 @@ static (int, string, string) Run(string file, string args)
 {
     var psi = new ProcessStartInfo(file, args) { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false };
     using var p = Process.Start(psi)!;
-    var so = p.StandardOutput.ReadToEnd();
-    var se = p.StandardError.ReadToEnd();
+    // Drain both pipes concurrently: reading stdout to EOF while the child blocks on a
+    // full stderr pipe buffer (or vice versa) deadlocks both processes.
+    var so = p.StandardOutput.ReadToEndAsync();
+    var se = p.StandardError.ReadToEndAsync();
+    System.Threading.Tasks.Task.WaitAll(so, se);
     p.WaitForExit();
-    return (p.ExitCode, so, se);
+    return (p.ExitCode, so.Result, se.Result);
 }
 
 static string? RunCapture(string file, string args)

--- a/.claude/hooks/30-test-gate.csx
+++ b/.claude/hooks/30-test-gate.csx
@@ -6,8 +6,10 @@
 //
 // Notes:
 //   * Assumes the build gate already ran locally before push (beforeCommit chain).
-//   * Uses --no-restore to minimise time but falls back to a full test if that fails.
+//   * Runs a plain `dotnet test MediatorLite.sln -c Release` (restore included).
 //   * Benchmarks are not run (they're BenchmarkDotNet programs, not xUnit tests).
+//   * If the dotnet SDK is missing, warns and allows the push (tests didn't fail —
+//     they couldn't run); override discipline is the same as the other gates.
 
 #load "../lib/ContextDb.csx"
 
@@ -24,7 +26,20 @@ if (Environment.GetEnvironmentVariable("MEDIATORLITE_SKIP_TESTS") == "1")
 }
 
 Console.WriteLine("[hook:30-test-gate] dotnet test MediatorLite.sln -c Release --nologo …");
-var (exit, stdout, stderr) = Run("dotnet", "test MediatorLite.sln -c Release --nologo -v q");
+(int exit, string stdout, string stderr) testResult;
+try
+{
+    testResult = Run("dotnet", "test MediatorLite.sln -c Release --nologo -v q");
+}
+catch (Exception ex)
+{
+    // Fail open: a machine without the SDK cannot run tests, which is not the same as
+    // tests failing. Crashing here used to hard-block the push with no explanation.
+    Console.Error.WriteLine($"[hook:30-test-gate] WARN — could not run dotnet ({ex.Message}); allowing push unverified");
+    ContextDb.LogHookEvent("30-test-gate.csx", "beforePush", "warn", sw.ElapsedMilliseconds, new { reason = "dotnet-missing" });
+    return;
+}
+var (exit, stdout, stderr) = testResult;
 if (exit == 0)
 {
     Console.WriteLine("[hook:30-test-gate] tests passed");
@@ -49,10 +64,13 @@ static (int, string, string) Run(string file, string args)
 {
     var psi = new ProcessStartInfo(file, args) { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false };
     using var p = Process.Start(psi)!;
-    var so = p.StandardOutput.ReadToEnd();
-    var se = p.StandardError.ReadToEnd();
+    // Drain both pipes concurrently: reading stdout to EOF while the child blocks on a
+    // full stderr pipe buffer (or vice versa) deadlocks both processes.
+    var so = p.StandardOutput.ReadToEndAsync();
+    var se = p.StandardError.ReadToEndAsync();
+    System.Threading.Tasks.Task.WaitAll(so, se);
     p.WaitForExit();
-    return (p.ExitCode, so, se);
+    return (p.ExitCode, so.Result, se.Result);
 }
 
 static string Tail(string s, int n) => string.IsNullOrEmpty(s) ? "" : (s.Length <= n ? s : s.Substring(s.Length - n));

--- a/.claude/rules/20-source-generator.md
+++ b/.claude/rules/20-source-generator.md
@@ -79,8 +79,12 @@ consumers can filter on the category:
             sb.AppendLine($"            __logger.LogDebug(\"Sending request {{RequestType}}\", \"{simpleRequest}\");");
 ```
 
-- Always `LogDebug`, never `LogInformation`/`LogError`. Level is a consumer
-  concern via `AddFilter("MediatorLite.IMediator", LogLevel.X)`.
+- Start/success lines are always `LogDebug`, never `LogInformation`. Level is a
+  consumer concern via `AddFilter("MediatorLite.IMediator", LogLevel.X)`.
+- The one exception: the emitted `catch` block logs the exception with
+  `LogError(__ex, ...)` before rethrowing. That is the existing shipped
+  behavior — do not downgrade it to `LogDebug` (consumers alert on it) and do
+  not add any other non-Debug call.
 - Skip the entire block when `[assembly: DisableMediatorLogging]` is present.
 
 ## Rule 5 — Tracing uses `ActivitySource "MediatorLite"`

--- a/.claude/rules/60-observability.md
+++ b/.claude/rules/60-observability.md
@@ -15,8 +15,11 @@ and notification. Consumers configure verbosity via standard
 builder.Logging.AddFilter("MediatorLite.IMediator", LogLevel.Information);
 ```
 
-- Always `LogDebug`. Do not introduce `LogInformation` / `LogWarning` calls
-  in generated code — the category-level filter is the only supported knob.
+- Start/success lines are always `LogDebug`. Do not introduce `LogInformation`
+  / `LogWarning` calls in generated code — the category-level filter is the
+  only supported knob. The single exception is the emitted `catch` block,
+  which logs the exception with `LogError(__ex, ...)` before rethrowing; that
+  is shipped behavior consumers alert on, so keep it.
 - Do not rename the category. The deleted `MediatorLoggingAttribute` (with
   its per-class `Enabled` / `IncludePayload` / `LogLevel`) was removed; do
   not reintroduce a per-type knob.

--- a/.claude/rules/70-testing.md
+++ b/.claude/rules/70-testing.md
@@ -16,8 +16,10 @@ tests/
       TestTypes.cs        # shared request/notification/handler/behavior fixtures
     UnitTests/            # narrow unit tests that do not spin up the mediator
   MediatorLite.Benchmarks/
-  MediatorLite.RestApiBenchmarks/
 ```
+
+(The former `MediatorLite.RestApiBenchmarks` REST harness has been removed from the
+repository; do not reference it in new tests or docs.)
 
 New source-gen-dependent fixtures go next to `TestTypes.cs`; do not create
 sibling fixture files if a type can live alongside existing ones.

--- a/.claude/rules/80-benchmarks.md
+++ b/.claude/rules/80-benchmarks.md
@@ -59,36 +59,17 @@ Do not sprinkle `.LogInformation` through handlers used by benchmarks — the
 `MediatorLite.IMediator` category already emits `LogDebug` for every
 request, so keep the benchmark's default filter at `Warning` or above.
 
-## Rule 4 — Parity harness lives in `BenchmarkParityGuard.cs`
+## Rule 4 — Keep MediatorLite/MediatR configurations at parity
 
-The REST API benchmark suite runs a parity check before any benchmark
-executes. Both mediator implementations must be configured with the same
-number of behaviors, notification handlers, and validators. Update the
-guard whenever you add or remove a registration:
+Both mediator implementations in a comparison suite must be configured with the
+same number of behaviors, notification handlers, and validators — otherwise the
+benchmark measures registration differences, not dispatch. When adding a new
+scenario, count the registrations on both sides and keep them equal.
 
-```51:77:tests/MediatorLite.RestApiBenchmarks/Hosting/BenchmarkParityGuard.cs
-    private static void ValidatePipelineParity(IServiceProvider serviceProvider, MediatorImplementation mediatorImplementation)
-    {
-        const int expectedBehaviorCount = 3;
-
-        if (mediatorImplementation == MediatorImplementation.MediatorLite)
-        {
-            var behaviorCount = serviceProvider
-                .GetServices<ML.IPipelineBehavior<CreateOrderCommand, CreateOrderResult>>()
-                .Count();
-
-            if (behaviorCount != expectedBehaviorCount)
-            {
-                throw new BenchmarkParityViolationException($"MediatorLite behavior count mismatch. Expected {expectedBehaviorCount}, got {behaviorCount}.");
-            }
-            ...
-        }
-```
-
-If a parity violation fires during `dotnet run -c Release` in
-`tests/MediatorLite.RestApiBenchmarks/`, fix the registration — do not bump
-the `expected*Count` constants without a matching change in the other
-mediator's pipeline.
+(The former `tests/MediatorLite.RestApiBenchmarks/` REST harness and its
+`BenchmarkParityGuard.cs` were removed from the repository. If a REST-style
+harness is reintroduced, restore an executable parity guard that fails fast on
+mismatched pipeline counts rather than relying on review.)
 
 ## Rule 5 — No shared state across benchmark classes
 

--- a/.github/Lessons/2026-07-02-incremental-generator-model-equality.md
+++ b/.github/Lessons/2026-07-02-incremental-generator-model-equality.md
@@ -1,0 +1,40 @@
+# Lesson: Incremental Generator Models Must Have Value Equality End-to-End
+
+## Metadata
+- PatternId: incremental-generator-model-equality
+- PatternVersion: 1
+- Status: active
+- Supersedes:
+- CreatedAt: 2026-07-02
+- LastValidatedAt: 2026-07-02
+- ValidationEvidence: `SourceGeneratorDriverTests.UnrelatedEdit_LeavesGeneratorOutputsCached` (runs the generator twice via `CSharpGeneratorDriver` with `trackIncrementalGeneratorSteps: true`, applies an unrelated edit, and asserts every tracked output step reason is `Cached`/`Unchanged`); full suite 87/87; clean `dotnet build MediatorLite.sln -c Release` with warnings-as-errors.
+
+## Task Context
+- Triggering task: Repo-wide adversarial bug hunt; generator reviewer flagged that `HandlerDiscoveryGenerator` regenerated both source files on every keystroke despite being an `IIncrementalGenerator`.
+- Date/time: 2026-07-02
+- Impacted area: `src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs` (pipeline wiring + model records), new `src/MediatorLite.SourceGeneration/EquatableArray.cs`.
+
+## Mistake
+- What went wrong: Two independent defects each fully defeated incremental caching:
+  1. Pipeline model records (`HandlerInfo`, `HandlerInterfaceInfo`, `NotificationHandlerInterfaceInfo`, `BehaviorInfo`) carried `List<>` members. Synthesized record equality compares collection members with `EqualityComparer<List<T>>.Default` — **reference equality** — and the transforms allocate fresh lists every run, so two structurally identical models never compared equal.
+  2. The final combine folded the raw `CompilationProvider` into the output node. A `Compilation` is a new instance on every edit, so `RegisterSourceOutput` re-ran regardless of model caching. The only compilation-level fact `Execute` needed was "is `MediatorLite.FluentValidation.FluentValidationBehavior`2` referenced".
+- Expected behavior: An edit that changes no discovered handler/behavior/validator leaves both generated files cached (rule `20-source-generator.md` §1).
+- Actual behavior: Every keystroke in any file of a consuming compilation re-ran `Execute` and re-emitted `MediatorLiteRegistration.g.cs` + `SourceGeneratedMediator.g.cs`.
+
+## Root Cause Analysis
+- Primary cause: Records give the *appearance* of value equality, but that guarantee stops at collection members — `List<T>` inside a record is compared by reference.
+- Contributing factors: Combining `CompilationProvider` directly is the documented anti-pattern in the incremental-generators cookbook, but it "works" functionally so nothing flagged it; the syntax-provider predicates being correct made the pipeline look incremental at a glance.
+- Detection gap: No test exercised the generator through `GeneratorDriver` with `trackIncrementalGeneratorSteps`, so cacheability regressions were invisible — the generator's *output* is identical whether or not caching works.
+
+## Resolution
+- Fix implemented: Added `EquatableArray<T>` (readonly struct, sequence equality + matching hash, `IEnumerable<T>` so existing LINQ keeps working) and replaced every `List<>` member of the model records with it; replaced the `CompilationProvider` combine with a projected provider — `Select(c => c.GetTypeByMetadataName("MediatorLite.FluentValidation.FluentValidationBehavior`2") is not null)` — so `Execute` takes a stable `bool` instead of the `Compilation`.
+- Why this fix works: Model equality is now structural at every level, so unchanged transforms are recognized as cached; the projected bool is value-equal across edits, so the output node's inputs only change when a discovered model or the FluentValidation reference actually changes.
+- Verification performed: The cacheability driver test above (fails on the old code, passes on the new), plus the full test suite and Release build.
+
+## Preventive Actions
+- Guardrails added: `EquatableArray<T>` doc comment explains *why* it exists; a comment block above the model records forbids `List<>` members.
+- Tests/checks added: `tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs` — `UnrelatedEdit_LeavesGeneratorOutputsCached` pins cacheability permanently.
+- Process updates: Any new field on a pipeline model record must itself have value equality (string, primitive, record, or `EquatableArray<T>`); any new compilation-level fact must be projected to an equatable value via `Select` before combining, never passed as the `Compilation`.
+
+## Reuse Guidance
+- How to apply this lesson in future tasks: When touching `Initialize()` or the model records, ask two questions — (1) does every model member compare by value? (2) does anything downstream of `RegisterSourceOutput` receive a `Compilation`, `ISymbol`, or `SyntaxNode`? If either answer is wrong, caching is silently dead even though builds stay green; only a `trackIncrementalGeneratorSteps` driver test can prove it. Applies to any Roslyn incremental generator, not just this repo.

--- a/.github/Memories/medl1002-open-behavior-shape.md
+++ b/.github/Memories/medl1002-open-behavior-shape.md
@@ -1,0 +1,28 @@
+# Memory: Open Generic Behavior Expansion Contract — Canonical Shape or MEDL1002
+
+## Metadata
+- PatternId: open-behavior-expansion-contract
+- PatternVersion: 1
+- Status: active
+- Supersedes:
+- CreatedAt: 2026-07-02
+- LastValidatedAt: 2026-07-02
+- ValidationEvidence: `SourceGeneratorDriverTests.ConstrainedOpenBehavior_ReportsMedl1002_AndIsNotRegistered` (extra-constraint behavior → single MEDL1002, type absent from generated output) and `CanonicalOpenBehavior_DoesNotReportMedl1002` (canonical shape still expands); full suite 87/87.
+
+## Source Context
+- Triggering task: Repo-wide bug hunt found `ExpandBehaviors` blindly substituting every discovered (request, response) pair into any open behavior — a partially-open behavior (`Foo<TResponse> : IPipelineBehavior<ConcreteReq, TResponse>`) or one with extra constraints (`where TRequest : IRequest<TResponse>, IAuditable`) produced `.g.cs` code that failed to compile with opaque errors.
+- Scope/system: Source generator behavior discovery/expansion (`HandlerDiscoveryGenerator`), generated DI registration, and the unrolled request pipelines.
+- Date/time: 2026-07-02
+
+## Memory
+- Key fact or decision: **Open generic pipeline behaviors are expandable only in the canonical shape** — exactly two type parameters, used directly and in order as `IPipelineBehavior<TRequest, TResponse>`'s type arguments, with no constraints beyond the interface-mandated `where TRequest : IRequest<TResponse>` (no extra constraint types, no `class`/`struct`/`notnull`/`unmanaged`/`new()`). The check is `IsSupportedOpenShape` in `HandlerDiscoveryGenerator.cs`, evaluated at discovery time in `GetBehaviorInfo`. Anything else sets `BehaviorInfo.HasUnsupportedOpenShape`, is **excluded from expansion and registration**, and is surfaced in `Execute` as the **MEDL1002 warning** (registered in `AnalyzerReleases.Unshipped.md`), naming the offending behavior.
+- Why it matters: Expansion works by textually substituting each discovered (request, response) pair for the class's type parameters. Outside the canonical shape that substitution produces closed types with wrong arity, swapped parameters, or unsatisfied constraints — generated code that fails the *consumer's* build with confusing errors pointing into a `.g.cs` file. Skipping + warning turns a cryptic build break into one actionable diagnostic; closed behaviors (bound to a concrete request type) remain unrestricted and are the escape hatch.
+
+## Applicability
+- When to reuse: Reviewing or extending `GetBehaviorInfo`/`IsSupportedOpenShape`/`ExpandBehaviors`; answering "why isn't my open behavior running?" (check build output for MEDL1002); designing any future generator feature that closes user generics over discovered types (e.g. open generic validators would need the same shape gate).
+- Preconditions/limitations: The gate is shape-based, not semantic — it does not attempt per-request constraint satisfaction (a behavior constrained to `IAuditable` is skipped entirely rather than applied to only the auditable requests). Lifting that limitation means filtering the request/response pairs per constraint instead of rejecting the behavior; until then MEDL1002 is the contract.
+
+## Actionable Guidance
+- Recommended future action: Keep MEDL1002 warning-severity (consumer builds with warnings-as-errors will still fail fast, others keep building); never let an unsupported shape silently vanish without the diagnostic, and never emit the closed type "optimistically". If a consumer needs a constrained behavior, point them to a closed behavior per request type.
+- Related files/services/components: `src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs` (`IsSupportedOpenShape`, `GetBehaviorInfo`, `ExpandBehaviors`, `UnsupportedOpenBehaviorShape` descriptor), `src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md`, `tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs`, rule `.claude/rules/30-pipeline-behaviors.md` (Rule 4: open generics are auto-discovered — this memory defines the boundary of "auto").
+- Related memory: `parallel-notification-execution` (PatternId `parallel-notification-execution`) — same subsystem; that memory covers notification emission, this one covers behavior expansion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ See `.claude/agents.md` for the full team roster, routing rules, and escalation 
 | Orchestrator | `orchestrator` | Team lead; DB owner; mode selector; single entry point |
 | Scrum Master | `scrum-master` | Read-only planner; DoR/DoD; standup digest |
 | Backend Developer | `backend-developer` | `src/MediatorLite*/**` author |
-| Frontend Developer | `frontend-developer` | `samples/**` and REST benchmark harness |
+| Frontend Developer | `frontend-developer` | `samples/**` and consumer reproductions |
 | Tester | `tester` | `tests/**` author; TDD enforcer |
 | DevOps | `devops` | CI/CD, hooks, publish, benchmarks, DB schema |
 | Code Reviewer | `code-reviewer` | Read-only diff reviewer; `reviews` table owner |
@@ -98,7 +98,7 @@ Code registers them automatically as skills from `.claude/skills/*/SKILL.md`.
 | `mediatorlite-tests` | Test layout; fixture patterns; `*Count` assertions |
 | `mediatorlite-benchmarks` | BenchmarkDotNet setup; MediatR comparison |
 | `mediatorlite-sample-sourcegen` | Canonical consumer wiring; `samples/**` |
-| `mediatorlite-rest-api-benchmarks` | `ApiBenchmarkHost`; REST harness |
+| `mediatorlite-rest-api-benchmarks` | Historical only — the REST harness project was removed from the repo |
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -86,21 +86,7 @@ Results are written to `BenchmarkDotNet.Artifacts/results/`.
 
 ## REST API Benchmarks (Production-Like)
 
-The repository also includes a REST API benchmark project at `tests/MediatorLite.RestApiBenchmarks`.
-This suite compares MediatorLite and MediatR in end-to-end API scenarios backed by SQLite:
-
-- In-process transport (`TestServer`) and real localhost transport (`Kestrel`)
-- Read-heavy and write-heavy API operations
-- Concurrency scenarios with multiple in-flight requests
-
-Run read/write benchmarks:
-
-```bash
-dotnet run -c Release --project tests/MediatorLite.RestApiBenchmarks -- --filter '*RestApiReadWriteBenchmarks*'
-```
-
-Run concurrency benchmarks:
-
-```bash
-dotnet run -c Release --project tests/MediatorLite.RestApiBenchmarks -- --filter '*RestApiConcurrencyBenchmarks*'
-```
+A REST API benchmark project (`tests/MediatorLite.RestApiBenchmarks`) previously compared
+MediatorLite and MediatR in end-to-end API scenarios (TestServer/Kestrel transports,
+read/write mixes, concurrency) backed by SQLite. It has been removed from the repository;
+this section is kept as a pointer for anyone reading older results that reference it.

--- a/src/MediatorLite.Abstractions/Abstractions/Attributes.cs
+++ b/src/MediatorLite.Abstractions/Abstractions/Attributes.cs
@@ -12,7 +12,9 @@ public enum NotificationExecutionStrategy
     Sequential = 0,
 
     /// <summary>
-    /// Execute all handlers concurrently using Task.WhenAll.
+    /// Start all handlers before awaiting any of them (cooperative <see cref="ValueTask"/>
+    /// fan-out). Handlers overlap at their await suspension points; there is no thread
+    /// offload and no <c>Task.WhenAll</c>. Started handlers are awaited in start order.
     /// </summary>
     Parallel = 1,
 
@@ -106,7 +108,7 @@ public sealed class NotificationHandlerOrderAttribute(int order) : Attribute
 /// runtime effect.
 /// </para>
 /// </remarks>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 public sealed class NotificationExecutionAttribute(NotificationExecutionStrategy strategy) : Attribute
 {
     /// <summary>
@@ -131,7 +133,7 @@ public sealed class NotificationExecutionAttribute(NotificationExecutionStrategy
 /// runtime effect.
 /// </para>
 /// </remarks>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 public sealed class NotificationErrorAttribute(NotificationErrorStrategy strategy) : Attribute
 {
     /// <summary>

--- a/src/MediatorLite.Abstractions/Validation/ValidationException.cs
+++ b/src/MediatorLite.Abstractions/Validation/ValidationException.cs
@@ -17,8 +17,9 @@ public sealed class ValidationException : Exception
     /// Initializes a new instance of the <see cref="ValidationException"/> class.
     /// </summary>
     /// <param name="errors">The validation errors.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="errors"/> is <see langword="null"/>.</exception>
     public ValidationException(IEnumerable<ValidationError> errors)
-        : this([.. errors])
+        : this(Freeze(errors))
     {
     }
 
@@ -37,10 +38,19 @@ public sealed class ValidationException : Exception
     /// </summary>
     /// <param name="message">The error message.</param>
     /// <param name="errors">The validation errors.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="errors"/> is <see langword="null"/>.</exception>
     public ValidationException(string message, IEnumerable<ValidationError> errors)
         : base(message)
     {
-        Errors = errors.ToList();
+        Errors = Freeze(errors);
+    }
+
+    // Snapshot into an array so Errors is genuinely immutable regardless of which
+    // constructor ran — a live List<T> behind IReadOnlyList can be cast and mutated.
+    private static ValidationError[] Freeze(IEnumerable<ValidationError> errors)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+        return [.. errors];
     }
 
     private static string BuildMessage(IReadOnlyList<ValidationError> errors)

--- a/src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md
+++ b/src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MEDL1001 | MediatorLite.Validation | Error | FluentValidation validators were found but the MediatorLite.FluentValidation package is not referenced.
+MEDL1002 | MediatorLite.Behaviors | Warning | An open generic pipeline behavior does not match the supported Behavior<TRequest, TResponse> shape and was not registered.

--- a/src/MediatorLite.SourceGeneration/EquatableArray.cs
+++ b/src/MediatorLite.SourceGeneration/EquatableArray.cs
@@ -62,17 +62,20 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnu
 
     public override int GetHashCode()
     {
-        if (_items is null)
-        {
-            return 0;
-        }
-
+        // A default (null-backed) instance and an explicitly empty array compare equal via
+        // Equals, so they must hash identically. Do not early-return a different constant for
+        // null: fall through to the same seed the empty-loop produces, or hash-based caches
+        // (and record hashing) can miss equal values — defeating the incremental caching this
+        // type exists to support.
         unchecked
         {
             var hash = 17;
-            foreach (var item in _items)
+            if (_items is not null)
             {
-                hash = (hash * 31) + (item?.GetHashCode() ?? 0);
+                foreach (var item in _items)
+                {
+                    hash = (hash * 31) + (item?.GetHashCode() ?? 0);
+                }
             }
 
             return hash;

--- a/src/MediatorLite.SourceGeneration/EquatableArray.cs
+++ b/src/MediatorLite.SourceGeneration/EquatableArray.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MediatorLite.SourceGeneration;
+
+/// <summary>
+/// An immutable array with value (sequence) equality, for use in incremental-generator
+/// pipeline models. Records that carry <see cref="List{T}"/> members compare those members
+/// by reference, which defeats the incremental cache — every run produces "new" models and
+/// forces full regeneration. Wrapping collections in this type restores structural equality
+/// so unchanged models are recognized as cached.
+/// </summary>
+/// <typeparam name="T">The element type; must itself have value equality.</typeparam>
+internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+    where T : IEquatable<T>
+{
+    private readonly T[]? _items;
+
+    public EquatableArray(T[] items)
+    {
+        _items = items;
+    }
+
+    /// <summary>Gets the number of elements. The default instance is empty.</summary>
+    public int Count => _items?.Length ?? 0;
+
+    /// <summary>Gets the element at the given index.</summary>
+    public T this[int index] => _items![index];
+
+    public bool Equals(EquatableArray<T> other)
+    {
+        var left = _items;
+        var right = other._items;
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return (left?.Length ?? 0) == (right?.Length ?? 0);
+        }
+
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (!EqualityComparer<T>.Default.Equals(left[i], right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        if (_items is null)
+        {
+            return 0;
+        }
+
+        unchecked
+        {
+            var hash = 17;
+            foreach (var item in _items)
+            {
+                hash = (hash * 31) + (item?.GetHashCode() ?? 0);
+            }
+
+            return hash;
+        }
+    }
+
+    public IEnumerator<T> GetEnumerator()
+        => ((IEnumerable<T>)(_items ?? [])).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -1616,17 +1616,23 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Converts a fully qualified type name to a safe C# identifier.
+    /// Converts a fully qualified type name to a safe C# identifier fragment.
+    /// Every character that is not a letter, digit, or underscore is mapped to '_' so the
+    /// result is always a valid identifier fragment — a whitelist of a few punctuation
+    /// characters is not enough once response type names reach the method name (e.g. an
+    /// array response <c>int[]</c> or a tuple <c>(int, string)</c> carries '[', ']', '(', ')').
+    /// Callers always prefix the result (Send_, Publish_, r_, n_), so a leading digit is fine.
     /// </summary>
     private static string GetSafeTypeName(string typeName)
     {
-        return typeName
-            .Replace("global::", "")
-            .Replace(".", "_")
-            .Replace("<", "_")
-            .Replace(">", "_")
-            .Replace(",", "_")
-            .Replace(" ", "");
+        var cleaned = typeName.Replace("global::", "");
+        var sb = new StringBuilder(cleaned.Length);
+        foreach (var c in cleaned)
+        {
+            sb.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -40,6 +40,25 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Reported when an open generic pipeline behavior cannot be expanded over the discovered
+    /// request types: expansion substitutes each (request, response) pair for the class's type
+    /// parameters, which is only valid for the canonical
+    /// <c>Behavior&lt;TRequest, TResponse&gt; : IPipelineBehavior&lt;TRequest, TResponse&gt;</c>
+    /// shape with no extra constraints. Emitting anything else would produce generated code
+    /// that fails to compile, so the behavior is skipped and surfaced here instead.
+    /// </summary>
+    private static readonly DiagnosticDescriptor UnsupportedOpenBehaviorShape = new(
+        id: "MEDL1002",
+        title: "Open generic pipeline behavior has an unsupported shape",
+        messageFormat: "Pipeline behavior '{0}' implements an open IPipelineBehavior<,> but does not match "
+            + "the supported shape Behavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> "
+            + "with no constraints beyond 'where TRequest : IRequest<TResponse>'. The behavior was not "
+            + "registered. Close the behavior over concrete types or remove the extra type parameters/constraints.",
+        category: "MediatorLite.Behaviors",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Find all class declarations that might be handlers
@@ -74,19 +93,25 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         var assemblyDefaults = context.CompilationProvider
             .Select(static (compilation, _) => GetAssemblyDefaults(compilation));
 
-        // Combine with compilation
-        var compilationAndData = context.CompilationProvider
-            .Combine(handlerDeclarations.Collect())
+        // Project the only compilation-level fact Execute needs into a stable bool instead of
+        // combining the Compilation itself: a raw Compilation is a new instance on every edit
+        // and would force the output node to rerun on every keystroke.
+        var hasFluentValidationReference = context.CompilationProvider
+            .Select(static (compilation, _) =>
+                compilation.GetTypeByMetadataName("MediatorLite.FluentValidation.FluentValidationBehavior`2") is not null);
+
+        var combinedData = handlerDeclarations.Collect()
             .Combine(notificationDeclarations.Collect())
             .Combine(behaviorDeclarations.Collect())
             .Combine(validatorDeclarations.Collect())
-            .Combine(assemblyDefaults);
+            .Combine(assemblyDefaults)
+            .Combine(hasFluentValidationReference);
 
         // Generate the output
-        context.RegisterSourceOutput(compilationAndData, static (spc, source) =>
+        context.RegisterSourceOutput(combinedData, static (spc, source) =>
         {
-            var (((((compilation, handlers), notifications), behaviors), validators), defaults) = source;
-            Execute(spc, compilation, handlers!, notifications!, behaviors!, validators!, defaults);
+            var (((((handlers, notifications), behaviors), validators), defaults), hasFluentValidation) = source;
+            Execute(spc, handlers!, notifications!, behaviors!, validators!, defaults, hasFluentValidation);
         });
     }
 
@@ -145,9 +170,12 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
 
     private static bool IsHandlerCandidate(SyntaxNode node)
     {
-        return node is ClassDeclarationSyntax classDecl
-               && classDecl.BaseList is not null
-               && !classDecl.Modifiers.Any(SyntaxKind.AbstractKeyword);
+        // Classes and (reference-type) records alike can implement handler interfaces;
+        // record structs are excluded because DI implementation types must be classes.
+        return node is (ClassDeclarationSyntax or RecordDeclarationSyntax) and TypeDeclarationSyntax typeDecl
+               && !node.IsKind(SyntaxKind.RecordStructDeclaration)
+               && typeDecl.BaseList is not null
+               && !typeDecl.Modifiers.Any(SyntaxKind.AbstractKeyword);
     }
 
     private static bool IsNotificationCandidate(SyntaxNode node)
@@ -200,20 +228,15 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             ErrorStrategy: errorStrategy);
     }
 
-    private static bool IsBehaviorCandidate(SyntaxNode node)
-    {
-        return node is ClassDeclarationSyntax classDecl
-               && classDecl.BaseList is not null
-               && !classDecl.Modifiers.Any(SyntaxKind.AbstractKeyword);
-    }
+    private static bool IsBehaviorCandidate(SyntaxNode node) => IsHandlerCandidate(node);
 
     private static BehaviorInfo? GetBehaviorInfo(GeneratorSyntaxContext context, CancellationToken ct)
     {
-        var classDecl = (ClassDeclarationSyntax)context.Node;
+        var typeDecl = (TypeDeclarationSyntax)context.Node;
         var semanticModel = context.SemanticModel;
-        var classSymbol = semanticModel.GetDeclaredSymbol(classDecl, ct) as INamedTypeSymbol;
+        var classSymbol = semanticModel.GetDeclaredSymbol(typeDecl, ct) as INamedTypeSymbol;
 
-        if (classSymbol is null || classSymbol.IsAbstract)
+        if (classSymbol is null || classSymbol.IsAbstract || !classSymbol.IsReferenceType)
             return null;
 
         var hasSkipAttribute = classSymbol.GetAttributes()
@@ -226,6 +249,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         var behaviorInterfaces = new List<BehaviorInterfaceInfo>();
         bool isOpenGeneric = classSymbol.IsGenericType && classSymbol.IsUnboundGenericType == false
                              && classSymbol.TypeParameters.Length > 0;
+        bool hasUnsupportedOpenShape = false;
 
         foreach (var iface in classSymbol.AllInterfaces)
         {
@@ -241,6 +265,19 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 {
                     bool isInterfaceOpen = typeArgs.Any(t => t.TypeKind == TypeKind.TypeParameter);
 
+                    // Open interfaces are expanded by substituting each discovered
+                    // (request, response) pair for the class's type parameters. That is only
+                    // valid for the canonical shape Behavior<TRequest, TResponse> with no
+                    // constraints beyond `where TRequest : IRequest<TResponse>` — anything
+                    // else would emit closed types that do not compile (wrong arity, swapped
+                    // parameters, or unsatisfied constraints). Such behaviors are skipped and
+                    // surfaced via MEDL1002 instead.
+                    if (isInterfaceOpen && !IsSupportedOpenShape(classSymbol, iface))
+                    {
+                        hasUnsupportedOpenShape = true;
+                        continue;
+                    }
+
                     behaviorInterfaces.Add(new BehaviorInterfaceInfo(
                         InterfaceType: iface.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                         RequestType: isInterfaceOpen ? null : typeArgs[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
@@ -250,7 +287,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             }
         }
 
-        if (behaviorInterfaces.Count == 0)
+        if (behaviorInterfaces.Count == 0 && !hasUnsupportedOpenShape)
             return null;
 
         // Extract BehaviorOrderAttribute if present
@@ -265,25 +302,67 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         return new BehaviorInfo(
             ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
-            BehaviorInterfaces: behaviorInterfaces,
+            BehaviorInterfaces: new EquatableArray<BehaviorInterfaceInfo>(behaviorInterfaces.ToArray()),
             IsOpenGeneric: isOpenGeneric,
-            Order: behaviorOrder);
+            Order: behaviorOrder,
+            HasUnsupportedOpenShape: hasUnsupportedOpenShape);
     }
 
-    private static bool IsValidatorCandidate(SyntaxNode node)
+    /// <summary>
+    /// A behavior's open <c>IPipelineBehavior&lt;,&gt;</c> interface can be expanded over all
+    /// discovered request/response pairs only when the class has exactly two type parameters
+    /// used directly, in order, as the interface's type arguments, and the parameters carry no
+    /// constraints beyond the interface-mandated <c>where TRequest : IRequest&lt;TResponse&gt;</c>.
+    /// </summary>
+    private static bool IsSupportedOpenShape(INamedTypeSymbol classSymbol, INamedTypeSymbol iface)
     {
-        return node is ClassDeclarationSyntax classDecl
-               && classDecl.BaseList is not null
-               && !classDecl.Modifiers.Any(SyntaxKind.AbstractKeyword);
+        if (classSymbol.TypeParameters.Length != 2)
+            return false;
+
+        var requestParam = classSymbol.TypeParameters[0];
+        var responseParam = classSymbol.TypeParameters[1];
+
+        if (!SymbolEqualityComparer.Default.Equals(iface.TypeArguments[0], requestParam)
+            || !SymbolEqualityComparer.Default.Equals(iface.TypeArguments[1], responseParam))
+        {
+            return false;
+        }
+
+        if (HasSpecialConstraints(requestParam) || HasSpecialConstraints(responseParam)
+            || responseParam.ConstraintTypes.Length > 0)
+        {
+            return false;
+        }
+
+        foreach (var constraint in requestParam.ConstraintTypes)
+        {
+            var isRequestConstraint = constraint is INamedTypeSymbol { TypeArguments.Length: 1 } named
+                && named.OriginalDefinition.ToDisplayString() == "MediatorLite.IRequest<TResponse>"
+                && SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], responseParam);
+
+            if (!isRequestConstraint)
+                return false;
+        }
+
+        return true;
+
+        static bool HasSpecialConstraints(ITypeParameterSymbol parameter)
+            => parameter.HasReferenceTypeConstraint
+               || parameter.HasValueTypeConstraint
+               || parameter.HasNotNullConstraint
+               || parameter.HasUnmanagedTypeConstraint
+               || parameter.HasConstructorConstraint;
     }
+
+    private static bool IsValidatorCandidate(SyntaxNode node) => IsHandlerCandidate(node);
 
     private static ValidatorInfo? GetValidatorInfo(GeneratorSyntaxContext context, CancellationToken ct)
     {
-        var classDecl = (ClassDeclarationSyntax)context.Node;
+        var typeDecl = (TypeDeclarationSyntax)context.Node;
         var semanticModel = context.SemanticModel;
-        var classSymbol = semanticModel.GetDeclaredSymbol(classDecl, ct) as INamedTypeSymbol;
+        var classSymbol = semanticModel.GetDeclaredSymbol(typeDecl, ct) as INamedTypeSymbol;
 
-        if (classSymbol is null || classSymbol.IsAbstract)
+        if (classSymbol is null || classSymbol.IsAbstract || !classSymbol.IsReferenceType)
             return null;
 
         // Skip open generic validators (e.g., a user's own generic AbstractValidator<T>)
@@ -334,7 +413,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
     /// Used to order switch arms most-derived-first so type-pattern dispatch preserves
     /// runtime-type specificity when message types inherit from each other.
     /// </summary>
-    private static List<string> GetBaseTypeNames(ITypeSymbol type)
+    private static EquatableArray<string> GetBaseTypeNames(ITypeSymbol type)
     {
         var result = new List<string>();
         var current = type.BaseType;
@@ -343,7 +422,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             result.Add(current.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
             current = current.BaseType;
         }
-        return result;
+        return new EquatableArray<string>(result.ToArray());
     }
 
     /// <summary>
@@ -356,12 +435,12 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
     private static List<T> SortMostDerivedFirst<T>(
         List<T> items,
         Func<T, string> typeName,
-        Func<T, List<string>?> baseTypes)
+        Func<T, EquatableArray<string>> baseTypes)
     {
         var dispatchedTypes = new HashSet<string>(items.Select(typeName));
         return items
             .Select((item, index) => (Item: item, Index: index,
-                Depth: baseTypes(item)?.Count(dispatchedTypes.Contains) ?? 0))
+                Depth: baseTypes(item).Count(dispatchedTypes.Contains)))
             .OrderByDescending(x => x.Depth)
             .ThenBy(x => x.Index)
             .Select(x => x.Item)
@@ -370,11 +449,11 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
 
     private static HandlerInfo? GetHandlerInfo(GeneratorSyntaxContext context, CancellationToken ct)
     {
-        var classDecl = (ClassDeclarationSyntax)context.Node;
+        var typeDecl = (TypeDeclarationSyntax)context.Node;
         var semanticModel = context.SemanticModel;
-        var classSymbol = semanticModel.GetDeclaredSymbol(classDecl, ct) as INamedTypeSymbol;
+        var classSymbol = semanticModel.GetDeclaredSymbol(typeDecl, ct) as INamedTypeSymbol;
 
-        if (classSymbol is null || classSymbol.IsAbstract)
+        if (classSymbol is null || classSymbol.IsAbstract || !classSymbol.IsReferenceType)
             return null;
 
         var hasSkipAttribute = classSymbol.GetAttributes()
@@ -434,23 +513,33 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         return new HandlerInfo(
             ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
-            RequestHandlers: requestHandlerInterfaces,
-            NotificationHandlers: notificationHandlerInterfaces);
+            RequestHandlers: new EquatableArray<HandlerInterfaceInfo>(requestHandlerInterfaces.ToArray()),
+            NotificationHandlers: new EquatableArray<NotificationHandlerInterfaceInfo>(notificationHandlerInterfaces.ToArray()));
     }
 
     private static void Execute(
         SourceProductionContext context,
-        Compilation compilation,
         ImmutableArray<HandlerInfo?> handlers,
         ImmutableArray<NotificationTypeInfo?> notifications,
         ImmutableArray<BehaviorInfo?> behaviors,
         ImmutableArray<ValidatorInfo?> validators,
-        AssemblyDefaults assemblyDefaults)
+        AssemblyDefaults assemblyDefaults,
+        bool hasFluentValidationReference)
     {
-        var validHandlers = handlers.Where(h => h is not null).Cast<HandlerInfo>().ToList();
-        var validNotifications = notifications.Where(n => n is not null).Cast<NotificationTypeInfo>().ToList();
-        var validBehaviors = behaviors.Where(b => b is not null).Cast<BehaviorInfo>().ToList();
-        var validValidators = validators.Where(v => v is not null).Cast<ValidatorInfo>().ToList();
+        // Dedupe by fully-qualified name: the syntax providers run the transform once per
+        // declaration node, so a partial type whose declarations each carry a base list is
+        // discovered once per declaration. Without this, a partial notification handler would
+        // be registered — and invoked — once per part.
+        var validHandlers = DistinctByName(handlers, h => h.ClassName);
+        var validNotifications = DistinctByName(notifications, n => n.TypeName);
+        var validBehaviors = DistinctByName(behaviors, b => b.ClassName);
+        var validValidators = DistinctByName(validators, v => v.ClassName);
+
+        foreach (var behavior in validBehaviors.Where(b => b.HasUnsupportedOpenShape))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                UnsupportedOpenBehaviorShape, Location.None, StripGlobalPrefix(behavior.ClassName)));
+        }
 
         if (validHandlers.Count == 0)
         {
@@ -471,7 +560,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         // the developer sees exactly one actionable error rather than a cascade of missing-type
         // errors. MEDL1001 is error-severity, so validation can never silently fail to run.
         if (requestTypesWithValidation.Count > 0
-            && compilation.GetTypeByMetadataName("MediatorLite.FluentValidation.FluentValidationBehavior`2") is null)
+            && !hasFluentValidationReference)
         {
             context.ReportDiagnostic(Diagnostic.Create(MissingFluentValidationPackage, Location.None));
             requestTypesWithValidation = new List<(string RequestType, string ResponseType)>();
@@ -489,6 +578,26 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
 
         GenerateRegistrationCode(context, validHandlers, expandedBehaviors, validValidators, requestTypesWithValidation);
         GenerateSourceGeneratedMediator(context, validHandlers, validNotifications, validBehaviors, expandedBehaviors, assemblyDefaults);
+    }
+
+    /// <summary>
+    /// Filters out nulls and keeps the first occurrence per fully-qualified name.
+    /// See the call site in <see cref="Execute"/> for why duplicates can occur (partial types).
+    /// </summary>
+    private static List<T> DistinctByName<T>(ImmutableArray<T?> items, Func<T, string> name)
+        where T : class
+    {
+        var seen = new HashSet<string>();
+        var result = new List<T>();
+        foreach (var item in items)
+        {
+            if (item is not null && seen.Add(name(item)))
+            {
+                result.Add(item);
+            }
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -880,17 +989,22 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             g => g.NotificationType,
             g => g.Handlers[0].Interface.BaseTypes);
 
-        // One dispatch entry (switch arm + Send_* method) per request type. Duplicate handler
-        // registrations for the same request type collapse to a single entry — resolution via
-        // IRequestHandler<,> picks the last DI registration, matching previous behavior.
-        var dispatchEntries = requestHandlers
+        // One switch arm per request type. Duplicate handlers for the same (request, response)
+        // pair collapse to a single entry — resolution via IRequestHandler<,> picks the last DI
+        // registration, matching previous behavior. A request type may implement IRequest<T>
+        // for several T (each with its own handler); every distinct response type keeps its own
+        // fully-typed Send_* pipeline inside the shared arm, selected by the TResponse guard.
+        var dispatchGroups = requestHandlers
             .GroupBy(rh => rh.Interface.RequestType)
-            .Select(g => g.First())
+            .Select(g => (
+                RequestType: g.Key,
+                BaseTypes: g.First().Interface.BaseTypes,
+                Entries: g.GroupBy(x => x.Interface.ResponseType).Select(rg => rg.First()).ToList()))
             .ToList();
-        dispatchEntries = SortMostDerivedFirst(
-            dispatchEntries,
-            rh => rh.Interface.RequestType,
-            rh => rh.Interface.BaseTypes);
+        dispatchGroups = SortMostDerivedFirst(
+            dispatchGroups,
+            g => g.RequestType,
+            g => g.BaseTypes);
 
         var sb = new StringBuilder();
         sb.AppendLine("// <auto-generated />");
@@ -931,20 +1045,53 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         sb.AppendLine("        {");
         sb.AppendLine("            switch (request)");
         sb.AppendLine("            {");
-        foreach (var (handler, iface) in dispatchEntries)
+        foreach (var group in dispatchGroups)
         {
-            var safeName = GetSafeTypeName(iface.RequestType);
-            sb.AppendLine($"                case {iface.RequestType} r_{safeName}:");
+            var safeName = GetSafeTypeName(group.RequestType);
+            sb.AppendLine($"                case {group.RequestType} r_{safeName}:");
             sb.AppendLine("                {");
-            sb.AppendLine($"                    var vt = Send_{safeName}(r_{safeName}, cancellationToken);");
-            sb.AppendLine($"                    if (typeof(TResponse) == typeof({iface.ResponseType}))");
-            sb.AppendLine("                    {");
-            sb.AppendLine("                        // SAFETY: guarded by the exact type-equality check above, this is an");
-            sb.AppendLine("                        // identity reinterpret (ValueTask<T> as ValueTask<T>). The guard is");
-            sb.AppendLine("                        // JIT-folded to a constant, so the cast itself is free.");
-            sb.AppendLine($"                        return Unsafe.As<ValueTask<{iface.ResponseType}>, ValueTask<TResponse>>(ref vt);");
-            sb.AppendLine("                    }");
-            sb.AppendLine($"                    return SlowCast<{iface.ResponseType}, TResponse>(vt);");
+
+            if (group.Entries.Count == 1)
+            {
+                var iface = group.Entries[0].Interface;
+                sb.AppendLine($"                    var vt = Send_{safeName}(r_{safeName}, cancellationToken);");
+                sb.AppendLine($"                    if (typeof(TResponse) == typeof({iface.ResponseType}))");
+                sb.AppendLine("                    {");
+                sb.AppendLine("                        // SAFETY: guarded by the exact type-equality check above, this is an");
+                sb.AppendLine("                        // identity reinterpret (ValueTask<T> as ValueTask<T>). The guard is");
+                sb.AppendLine("                        // JIT-folded to a constant, so the cast itself is free.");
+                sb.AppendLine($"                        return Unsafe.As<ValueTask<{iface.ResponseType}>, ValueTask<TResponse>>(ref vt);");
+                sb.AppendLine("                    }");
+                sb.AppendLine($"                    return SlowCast<{iface.ResponseType}, TResponse>(vt);");
+            }
+            else
+            {
+                foreach (var (_, iface) in group.Entries)
+                {
+                    var sendName = $"Send_{safeName}_{GetSafeTypeName(iface.ResponseType!)}";
+                    sb.AppendLine($"                    if (typeof(TResponse) == typeof({iface.ResponseType}))");
+                    sb.AppendLine("                    {");
+                    sb.AppendLine("                        // SAFETY: identity reinterpret guarded by the exact type-equality check.");
+                    sb.AppendLine($"                        var vt = {sendName}(r_{safeName}, cancellationToken);");
+                    sb.AppendLine($"                        return Unsafe.As<ValueTask<{iface.ResponseType}>, ValueTask<TResponse>>(ref vt);");
+                    sb.AppendLine("                    }");
+                }
+
+                sb.AppendLine("                    // Covariant dispatch (IRequest<out T>): pick the pipeline whose concrete");
+                sb.AppendLine("                    // response type is assignable to the requested TResponse.");
+                foreach (var (_, iface) in group.Entries)
+                {
+                    var sendName = $"Send_{safeName}_{GetSafeTypeName(iface.ResponseType!)}";
+                    sb.AppendLine($"                    if (typeof({iface.ResponseType}).IsAssignableTo(typeof(TResponse)))");
+                    sb.AppendLine("                    {");
+                    sb.AppendLine($"                        return SlowCast<{iface.ResponseType}, TResponse>({sendName}(r_{safeName}, cancellationToken));");
+                    sb.AppendLine("                    }");
+                }
+
+                sb.AppendLine("                    throw new InvalidOperationException(");
+                sb.AppendLine($"                        $\"Request type {StripGlobalPrefix(group.RequestType)} has no handler producing response type {{typeof(TResponse).FullName}}.\");");
+            }
+
             sb.AppendLine("                }");
         }
         sb.AppendLine("                case null:");
@@ -992,26 +1139,35 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         sb.AppendLine("        // ═══════════════════════════════════════════════════════════════════════════════");
         sb.AppendLine();
 
-        foreach (var (handler, iface) in dispatchEntries)
+        foreach (var group in dispatchGroups)
         {
-            var safeName = GetSafeTypeName(iface.RequestType);
-            var requestType = iface.RequestType;
-            var responseType = iface.ResponseType!;
+            var multipleResponses = group.Entries.Count > 1;
+            foreach (var (_, iface) in group.Entries)
+            {
+                var requestType = iface.RequestType;
+                var responseType = iface.ResponseType!;
 
-            // Get behaviors for this request type, sorted by order
-            var key = (requestType, responseType);
-            var behaviorsForRequest = behaviorsByRequest.ContainsKey(key)
-                ? behaviorsByRequest[key]
-                : new List<ExpandedBehaviorInfo>();
+                // Multi-response request types get one Send_* method per response type; the
+                // name must stay in sync with the switch-arm emission above.
+                var safeName = multipleResponses
+                    ? $"{GetSafeTypeName(requestType)}_{GetSafeTypeName(responseType)}"
+                    : GetSafeTypeName(requestType);
 
-            GenerateUnrolledPipeline(
-                sb,
-                safeName,
-                requestType,
-                responseType,
-                behaviorsForRequest,
-                loggingEnabled: !assemblyDefaults.LoggingDisabled,
-                tracingEnabled: !assemblyDefaults.TracingDisabled);
+                // Get behaviors for this request type, sorted by order
+                var key = (requestType, responseType);
+                var behaviorsForRequest = behaviorsByRequest.ContainsKey(key)
+                    ? behaviorsByRequest[key]
+                    : new List<ExpandedBehaviorInfo>();
+
+                GenerateUnrolledPipeline(
+                    sb,
+                    safeName,
+                    requestType,
+                    responseType,
+                    behaviorsForRequest,
+                    loggingEnabled: !assemblyDefaults.LoggingDisabled,
+                    tracingEnabled: !assemblyDefaults.TracingDisabled);
+            }
         }
 
         // === UNROLLED NOTIFICATION PUBLISHERS ===
@@ -1074,7 +1230,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         // name by taking the substring after the last '.'.
         var fullRequest = StripGlobalPrefix(requestType);
         var fullResponse = StripGlobalPrefix(responseType);
-        var simpleRequest = requestType.Substring(requestType.LastIndexOf('.') + 1);
+        var simpleRequest = GetSimpleDisplayName(requestType);
 
         // The nested behavior/handler invocation chain, built outside-in. With no behaviors
         // this is just the handler call.
@@ -1187,7 +1343,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         bool tracingEnabled)
     {
         var fullNotification = StripGlobalPrefix(notificationType);
-        var simpleNotification = notificationType.Substring(notificationType.LastIndexOf('.') + 1);
+        var simpleNotification = GetSimpleDisplayName(notificationType);
 
         void EmitStrategyBody()
         {
@@ -1202,7 +1358,13 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             }
             else if (executionStrategy == 2) // StopOnFirst
             {
-                GenerateStopOnFirstNotificationExecution(sb, notificationType, handlers, errorStrategy);
+                // StopOnFirst returns from inside the strategy body on the first successful
+                // handler, bypassing the wrapper's post-body success log — so the success log
+                // statement is passed in and emitted before each early return instead.
+                var successLogStatement = loggingEnabled
+                    ? $"__logger.LogDebug(\"Notification {{NotificationType}} published successfully\", \"{simpleNotification}\");"
+                    : null;
+                GenerateStopOnFirstNotificationExecution(sb, notificationType, handlers, errorStrategy, successLogStatement);
             }
             else // Sequential (default)
             {
@@ -1366,6 +1528,15 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             sb.AppendLine("            {");
             sb.AppendLine("                // Prioritize cancellation - rethrow OperationCanceledException directly");
             sb.AppendLine("                ct.ThrowIfCancellationRequested();");
+            sb.AppendLine("                // Match sequential semantics: a handler's OperationCanceledException");
+            sb.AppendLine("                // surfaces unwrapped (first in start order), never inside an AggregateException.");
+            sb.AppendLine("                foreach (var __candidate in exceptions)");
+            sb.AppendLine("                {");
+            sb.AppendLine("                    if (__candidate is OperationCanceledException)");
+            sb.AppendLine("                    {");
+            sb.AppendLine("                        global::System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(__candidate).Throw();");
+            sb.AppendLine("                    }");
+            sb.AppendLine("                }");
             sb.AppendLine("                // For handler failures, throw an AggregateException with all exceptions");
             sb.AppendLine("                throw new AggregateException(exceptions);");
             sb.AppendLine("            }");
@@ -1390,7 +1561,8 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         StringBuilder sb,
         string notificationType,
         List<(HandlerInfo Handler, NotificationHandlerInterfaceInfo Interface)> handlers,
-        int errorStrategy)
+        int errorStrategy,
+        string? successLogStatement = null)
     {
         if (errorStrategy == 0) // StopOnFirstError
         {
@@ -1422,6 +1594,10 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 sb.AppendLine("            {");
                 sb.AppendLine("                ct.ThrowIfCancellationRequested();");
                 sb.AppendLine($"                await h{i + 1}.HandleAsync(notification, ct).ConfigureAwait(false);");
+                if (successLogStatement is not null)
+                {
+                    sb.AppendLine($"                {successLogStatement}");
+                }
                 sb.AppendLine("                return; // Success — stop here");
                 sb.AppendLine("            }");
                 sb.AppendLine("            catch (OperationCanceledException) { throw; }");
@@ -1462,25 +1638,43 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         const string prefix = "global::";
         return typeName.StartsWith(prefix) ? typeName.Substring(prefix.Length) : typeName;
     }
+
+    /// <summary>
+    /// Computes the simple display name of a fully-qualified type for log messages and
+    /// activity names. The namespace is stripped from the type itself, not from inside its
+    /// type arguments: a plain <c>LastIndexOf('.')</c> on a generic like
+    /// <c>Ns.Query&lt;System.String&gt;</c> would land inside the argument and yield "String&gt;".
+    /// </summary>
+    private static string GetSimpleDisplayName(string typeName)
+    {
+        var name = typeName.Replace("global::", "");
+        var genericStart = name.IndexOf('<');
+        var searchEnd = (genericStart >= 0 ? genericStart : name.Length) - 1;
+        var lastDot = searchEnd >= 0 ? name.LastIndexOf('.', searchEnd) : -1;
+        return lastDot >= 0 ? name.Substring(lastDot + 1) : name;
+    }
 }
+
+// Pipeline model records. All collection members use EquatableArray<T> (value equality):
+// List<T> members would compare by reference and permanently defeat incremental caching.
 
 internal sealed record HandlerInfo(
     string ClassName,
     string Namespace,
-    List<HandlerInterfaceInfo> RequestHandlers,
-    List<NotificationHandlerInterfaceInfo> NotificationHandlers);
+    EquatableArray<HandlerInterfaceInfo> RequestHandlers,
+    EquatableArray<NotificationHandlerInterfaceInfo> NotificationHandlers);
 
 internal sealed record HandlerInterfaceInfo(
     string InterfaceType,
     string RequestType,
     string? ResponseType,
-    List<string>? BaseTypes = null);
+    EquatableArray<string> BaseTypes = default);
 
 internal sealed record NotificationHandlerInterfaceInfo(
     string InterfaceType,
     string NotificationType,
     int? Order,
-    List<string>? BaseTypes = null);
+    EquatableArray<string> BaseTypes = default);
 
 internal sealed record NotificationTypeInfo(
     string TypeName,
@@ -1496,9 +1690,10 @@ internal readonly record struct AssemblyDefaults(
 internal sealed record BehaviorInfo(
     string ClassName,
     string Namespace,
-    List<BehaviorInterfaceInfo> BehaviorInterfaces,
+    EquatableArray<BehaviorInterfaceInfo> BehaviorInterfaces,
     bool IsOpenGeneric,
-    int Order = 0);
+    int Order = 0,
+    bool HasUnsupportedOpenShape = false);
 
 internal sealed record BehaviorInterfaceInfo(
     string InterfaceType,

--- a/src/MediatorLite.SourceGeneration/MediatorLite.SourceGeneration.csproj
+++ b/src/MediatorLite.SourceGeneration/MediatorLite.SourceGeneration.csproj
@@ -24,6 +24,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Lets the test project exercise internal helpers (e.g. EquatableArray<T>) directly. -->
+    <InternalsVisibleTo Include="MediatorLite.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Analyzer release tracking for declared diagnostics (RS2008). -->
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />

--- a/tests/MediatorLite.Tests/AssemblyInfo.cs
+++ b/tests/MediatorLite.Tests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Fixtures in SourceGeneration/TestTypes.cs track invocations through mutable statics
+// (rule 70 §6), and the open-generic behaviors (GenericLoggingBehavior,
+// ExecutionOrderTrackingBehavior) funnel *every* request from *every* test class through
+// the same static lists. xUnit runs test classes in parallel by default, so those lists
+// were racing across classes (concurrent List<T>.Add — an intermittent CI flake).
+// Serialize the whole assembly until the fixtures stop sharing static state.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/MediatorLite.Tests/MediatorLite.Tests.csproj
+++ b/tests/MediatorLite.Tests/MediatorLite.Tests.csproj
@@ -21,14 +21,17 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <!-- Drives the generator in-memory (diagnostics + incrementality tests in UnitTests) -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MediatorLite\MediatorLite.csproj" />
     <!-- FluentValidation integration (FluentValidationBehavior + FluentValidation) -->
     <ProjectReference Include="..\..\src\MediatorLite.FluentValidation\MediatorLite.FluentValidation.csproj" />
-    <!-- Source generator for SourceGeneration tests -->
-    <ProjectReference Include="..\..\src\MediatorLite.SourceGeneration\MediatorLite.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <!-- Source generator: analyzer for SourceGeneration tests AND compile reference so
+         UnitTests can construct it for GeneratorDriver-based tests -->
+    <ProjectReference Include="..\..\src\MediatorLite.SourceGeneration\MediatorLite.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
   </ItemGroup>
 
 </Project>

--- a/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
@@ -293,4 +293,27 @@ public class MediatorTests
         intResult.Should().Be(50);
         stringResult.Should().Be("value:5");
     }
+
+    [Fact]
+    public async Task SendAsync_MultiResponseWithArrayResponseType_DispatchesWithSanitizedMethodName()
+    {
+        // Arrange - ArrayItemsQuery is IRequest<int[]> and IRequest<string>. The int[] response
+        // display name ("int[]") flows into the generated Send_* method name; unsanitized
+        // brackets would emit an invalid identifier and this project would not have compiled.
+        var services = new ServiceCollection();
+        services.AddGeneratedHandlers();
+        services.AddMediatorLite();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        // Act
+        var arrayResult = await mediator.SendAsync<int[]>(new ArrayItemsQuery(3));
+        var stringResult = await mediator.SendAsync<string>(new ArrayItemsQuery(3));
+
+        // Assert
+        arrayResult.Should().Equal(0, 1, 2);
+        stringResult.Should().Be("count:3");
+    }
 }

--- a/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
@@ -250,4 +250,47 @@ public class MediatorTests
         var result = await mediator.SendAsync(new GetUserByIdQuery(1));
         result.Should().NotBeNull();
     }
+
+    [Fact]
+    public async Task SendAsync_RecordDeclaredHandler_IsDiscoveredAndDispatched()
+    {
+        // Arrange - RecordDeclaredQueryHandler is a `sealed record`, not a class. Records
+        // are a distinct syntax node, and the generator used to silently skip them.
+        var services = new ServiceCollection();
+        services.AddGeneratedHandlers();
+        services.AddMediatorLite();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        // Act
+        var result = await mediator.SendAsync(new RecordHandledQuery(1));
+
+        // Assert
+        result.Should().Be(101, "the record-declared handler adds 100 to the request value");
+    }
+
+    [Fact]
+    public async Task SendAsync_RequestWithMultipleResponseTypes_DispatchesEachResponseToItsHandler()
+    {
+        // Arrange - MultiResponseQuery implements both IRequest<int> and IRequest<string>.
+        // The generator used to collapse the request type to a single dispatch arm, so one
+        // of the two calls below threw InvalidCastException despite a registered handler.
+        var services = new ServiceCollection();
+        services.AddGeneratedHandlers();
+        services.AddMediatorLite();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        // Act
+        var intResult = await mediator.SendAsync<int>(new MultiResponseQuery(5));
+        var stringResult = await mediator.SendAsync<string>(new MultiResponseQuery(5));
+
+        // Assert
+        intResult.Should().Be(50);
+        stringResult.Should().Be("value:5");
+    }
 }

--- a/tests/MediatorLite.Tests/SourceGeneration/NotificationTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/NotificationTests.cs
@@ -89,7 +89,8 @@ public class NotificationTests
     [Fact]
     public async Task PublishAsync_WithNoHandlers_CompletesWithoutError()
     {
-        // Arrange - Create a notification type that has no handlers registered
+        // Arrange - OrphanEvent has no INotificationHandler<OrphanEvent> in this assembly,
+        // so publishing must hit the generated no-handler default arm and complete silently.
         var services = new ServiceCollection();
         services.AddMediatorLite();
         services.AddGeneratedHandlers();
@@ -99,8 +100,56 @@ public class NotificationTests
         var mediator = provider.GetRequiredService<IMediator>();
 
         // Act & Assert
-        Func<Task> act = async () => await mediator.PublishAsync(new UserCreatedEvent(1, "test@test.com"));
+        Func<Task> act = async () => await mediator.PublishAsync(new OrphanEvent("nobody listens"));
         await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task PublishAsync_ParallelAggregate_SurfacesOperationCanceledExceptionUnwrapped()
+    {
+        // Arrange - one parallel handler throws OperationCanceledException (for a token that
+        // is not the publish token), its sibling succeeds. Sequential publish surfaces the
+        // OCE unwrapped; parallel + ContinueAndAggregate must match instead of burying it
+        // inside an AggregateException. Every started handler still runs.
+        ParallelCancellingSiblingHandler.Reset();
+        var services = new ServiceCollection();
+        services.AddMediatorLite();
+        services.AddGeneratedHandlers();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        // Act
+        Func<Task> act = async () => await mediator.PublishAsync(new ParallelCancellingEvent("cancel"));
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        ParallelCancellingSiblingHandler.WasCalled.Should().BeTrue(
+            "parallel fan-out starts every handler before awaiting any of them");
+    }
+
+    [Fact]
+    public async Task PublishAsync_PartialHandlerClass_InvokesHandlerExactlyOnce()
+    {
+        // Arrange - PartialDeclaredEventHandler is declared in two partial parts, each with
+        // a base list. The generator visits every declaration node, so without deduplication
+        // the handler would be registered — and invoked — once per part.
+        PartialDeclaredEventHandler.Reset();
+        var services = new ServiceCollection();
+        services.AddMediatorLite();
+        services.AddGeneratedHandlers();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        // Act
+        await mediator.PublishAsync(new PartialHandledEvent("once"));
+
+        // Assert
+        PartialDeclaredEventHandler.CallCount.Should().Be(1,
+            "a handler split across partial declarations must be discovered once, not once per part");
     }
 
     [Fact]

--- a/tests/MediatorLite.Tests/SourceGeneration/PipelineBehaviorTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/PipelineBehaviorTests.cs
@@ -29,7 +29,8 @@ public class PipelineBehaviorTests
         // Act
         var result = await mediator.SendAsync(new ComputeValueQuery(5));
 
-        // Assert - Handler returns 5 * 2 = 10 (behaviors not applied)
+        // Assert - Handler returns 5 * 2 = 10; MultiplyByTwoBehavior (order 2, inner) doubles
+        // it to 20; AddOneBehavior (order 1, outer) adds 1 → 21.
         result.Should().Be(21, "All compile-time discovered behaviors execute successfully with handlers");
     }
 

--- a/tests/MediatorLite.Tests/SourceGeneration/TestTypes.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/TestTypes.cs
@@ -640,6 +640,29 @@ public sealed class MultiResponseStringHandler : IRequestHandler<MultiResponseQu
     }
 }
 
+// ── PR #22 P2: multi-response request whose response type name has non-identifier chars ──
+// int[] renders as "int[]"; the response suffix reaches the generated Send_* method name,
+// so unsanitized brackets would emit an invalid identifier and fail this project's build.
+// The fixture existing and compiling is the regression guard.
+
+public record ArrayItemsQuery(int Count) : IRequest<int[]>, IRequest<string>;
+
+public sealed class ArrayItemsIntArrayHandler : IRequestHandler<ArrayItemsQuery, int[]>
+{
+    public ValueTask<int[]> HandleAsync(ArrayItemsQuery request, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(Enumerable.Range(0, request.Count).ToArray());
+    }
+}
+
+public sealed class ArrayItemsStringHandler : IRequestHandler<ArrayItemsQuery, string>
+{
+    public ValueTask<string> HandleAsync(ArrayItemsQuery request, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult($"count:{request.Count}");
+    }
+}
+
 #endregion
 
 #region Parallel Cancellation Fixtures (F8)

--- a/tests/MediatorLite.Tests/SourceGeneration/TestTypes.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/TestTypes.cs
@@ -573,3 +573,103 @@ public sealed class ParallelPhaseHandler2 : INotificationHandler<ParallelPhaseEv
 }
 
 #endregion
+
+#region Bug-Hunt Regression Fixtures
+
+// ── F9: genuine zero-handler notification ────────────────────────────────────────────
+// No INotificationHandler<OrphanEvent> exists anywhere in this assembly; publishing it
+// must hit the generated `default: return default;` arm and complete silently.
+
+public record OrphanEvent(string Message) : INotification;
+
+// ── F2: record handler discovery ─────────────────────────────────────────────────────
+// Handlers declared as records compile like classes but are a different syntax node;
+// the generator used to silently skip them.
+
+public record RecordHandledQuery(int Value) : IRequest<int>;
+
+public sealed record RecordDeclaredQueryHandler : IRequestHandler<RecordHandledQuery, int>
+{
+    public ValueTask<int> HandleAsync(RecordHandledQuery request, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(request.Value + 100);
+    }
+}
+
+// ── F1: partial handler declared across two parts, each with a base list ─────────────
+// The generator's syntax provider visits every declaration node; without deduplication
+// the handler was registered — and invoked — once per part.
+
+public interface IPartialHandlerMarker;
+
+public partial class PartialDeclaredEventHandler : INotificationHandler<PartialHandledEvent>
+{
+    public static int CallCount { get; private set; }
+    public static void Reset() => CallCount = 0;
+
+    public ValueTask HandleAsync(PartialHandledEvent notification, CancellationToken cancellationToken = default)
+    {
+        CallCount++;
+        return ValueTask.CompletedTask;
+    }
+}
+
+public partial class PartialDeclaredEventHandler : IPartialHandlerMarker;
+
+public record PartialHandledEvent(string Message) : INotification;
+
+// ── F3: one request type dispatched with two distinct response types ─────────────────
+// MultiResponseQuery is handled both as IRequest<int> and as IRequest<string>; each
+// response type must reach its own handler through the shared switch arm.
+
+public record MultiResponseQuery(int Value) : IRequest<int>, IRequest<string>;
+
+public sealed class MultiResponseIntHandler : IRequestHandler<MultiResponseQuery, int>
+{
+    public ValueTask<int> HandleAsync(MultiResponseQuery request, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(request.Value * 10);
+    }
+}
+
+public sealed class MultiResponseStringHandler : IRequestHandler<MultiResponseQuery, string>
+{
+    public ValueTask<string> HandleAsync(MultiResponseQuery request, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult($"value:{request.Value}");
+    }
+}
+
+#endregion
+
+#region Parallel Cancellation Fixtures (F8)
+
+// Parallel + ContinueAndAggregate must surface a handler's OperationCanceledException
+// unwrapped (matching sequential semantics), never buried inside an AggregateException.
+[NotificationExecution(NotificationExecutionStrategy.Parallel)]
+[NotificationError(NotificationErrorStrategy.ContinueAndAggregate)]
+public record ParallelCancellingEvent(string Message) : INotification;
+
+public sealed class ParallelCancellingHandler : INotificationHandler<ParallelCancellingEvent>
+{
+    public ValueTask HandleAsync(ParallelCancellingEvent notification, CancellationToken cancellationToken = default)
+    {
+        // Unrelated token: the publish CancellationToken itself is NOT cancelled.
+        throw new OperationCanceledException("handler-internal cancellation");
+    }
+}
+
+[NotificationHandlerOrder(1)]
+public sealed class ParallelCancellingSiblingHandler : INotificationHandler<ParallelCancellingEvent>
+{
+    public static bool WasCalled { get; private set; }
+    public static void Reset() => WasCalled = false;
+
+    public ValueTask HandleAsync(ParallelCancellingEvent notification, CancellationToken cancellationToken = default)
+    {
+        WasCalled = true;
+        return ValueTask.CompletedTask;
+    }
+}
+
+#endregion

--- a/tests/MediatorLite.Tests/UnitTests/EquatableArrayTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/EquatableArrayTests.cs
@@ -42,7 +42,7 @@ public class EquatableArrayTests
     }
 
     [Fact]
-    public void Equals_DefaultAndEmpty_AreEqualAndZeroCount()
+    public void Equals_DefaultAndEmpty_AreEqualWithMatchingHashAndZeroCount()
     {
         EquatableArray<int> def = default;
         var empty = new EquatableArray<int>([]);
@@ -51,6 +51,8 @@ public class EquatableArrayTests
         empty.Count.Should().Be(0);
         def.Equals(empty).Should().BeTrue();
         def.Equals(default).Should().BeTrue();
+        // Equal values MUST hash equally, or hash-based caches miss them.
+        def.GetHashCode().Should().Be(empty.GetHashCode());
     }
 
     [Fact]

--- a/tests/MediatorLite.Tests/UnitTests/EquatableArrayTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/EquatableArrayTests.cs
@@ -1,0 +1,110 @@
+using System.Collections;
+using FluentAssertions;
+using MediatorLite.SourceGeneration;
+using Xunit;
+
+namespace MediatorLite.Tests.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="EquatableArray{T}"/> — the value-equality wrapper that keeps the
+/// incremental generator's pipeline models cacheable. Its equality/hash contract is what makes
+/// unchanged models compare equal across generator runs, so it is worth pinning directly.
+/// </summary>
+public class EquatableArrayTests
+{
+    [Fact]
+    public void Equals_SameContent_IsTrueWithEqualHash()
+    {
+        var a = new EquatableArray<int>([1, 2, 3]);
+        var b = new EquatableArray<int>([1, 2, 3]);
+
+        a.Equals(b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+        a.Equals((object)b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentLength_IsFalse()
+    {
+        var a = new EquatableArray<int>([1, 2, 3]);
+        var b = new EquatableArray<int>([1, 2]);
+
+        a.Equals(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentElement_IsFalse()
+    {
+        var a = new EquatableArray<string>(["x", "y"]);
+        var b = new EquatableArray<string>(["x", "z"]);
+
+        a.Equals(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_DefaultAndEmpty_AreEqualAndZeroCount()
+    {
+        EquatableArray<int> def = default;
+        var empty = new EquatableArray<int>([]);
+
+        def.Count.Should().Be(0);
+        empty.Count.Should().Be(0);
+        def.Equals(empty).Should().BeTrue();
+        def.Equals(default).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_SameBackingReference_ShortCircuitsTrue()
+    {
+        var backing = new[] { 5, 6 };
+        var a = new EquatableArray<int>(backing);
+        var b = new EquatableArray<int>(backing);
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_NonEquatableArrayObject_IsFalse()
+    {
+        var a = new EquatableArray<int>([1]);
+
+        a.Equals("not an array").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IndexerAndCount_ReturnElements()
+    {
+        var a = new EquatableArray<string>(["a", "b", "c"]);
+
+        a.Count.Should().Be(3);
+        a[0].Should().Be("a");
+        a[2].Should().Be("c");
+    }
+
+    [Fact]
+    public void Enumeration_YieldsAllElements_AndDefaultIsEmpty()
+    {
+        var a = new EquatableArray<int>([10, 20]);
+
+        a.Should().Equal(10, 20); // IEnumerable<int> path
+
+        var viaNonGeneric = new List<object?>();
+        foreach (var item in (IEnumerable)a)
+        {
+            viaNonGeneric.Add(item);
+        }
+
+        viaNonGeneric.Should().Equal(10, 20);
+
+        EquatableArray<int> def = default;
+        def.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetHashCode_Default_IsStable()
+    {
+        EquatableArray<int> def = default;
+
+        def.GetHashCode().Should().Be(default(EquatableArray<int>).GetHashCode());
+    }
+}

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -1,0 +1,154 @@
+using FluentAssertions;
+using MediatorLite.SourceGeneration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MediatorLite.Tests.UnitTests;
+
+/// <summary>
+/// Drives <see cref="HandlerDiscoveryGenerator"/> in-memory to pin behavior that cannot be
+/// observed from inside a normally-compiled test assembly: generator diagnostics that would
+/// fail this project's build (warnings are errors), and incremental-caching guarantees.
+/// </summary>
+public class SourceGeneratorDriverTests
+{
+    private const string HandlerSource = """
+        using MediatorLite;
+
+        namespace DriverTests;
+
+        public record PingQuery(int Value) : IRequest<int>;
+
+        public sealed class PingQueryHandler : IRequestHandler<PingQuery, int>
+        {
+            public ValueTask<int> HandleAsync(PingQuery request, CancellationToken cancellationToken = default)
+                => ValueTask.FromResult(request.Value);
+        }
+        """;
+
+    [Fact]
+    public void ConstrainedOpenBehavior_ReportsMedl1002_AndIsNotRegistered()
+    {
+        // An open behavior with a constraint beyond `where TRequest : IRequest<TResponse>`
+        // cannot be expanded over every request type; emitting it anyway used to produce
+        // generated code that failed to compile with opaque errors in the .g.cs file.
+        const string behaviorSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public interface IAuditable;
+
+            public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+                where TRequest : IRequest<TResponse>, IAuditable
+            {
+                public ValueTask<TResponse> HandleAsync(
+                    TRequest request,
+                    RequestHandlerDelegate<TResponse> next,
+                    CancellationToken cancellationToken = default)
+                    => next();
+            }
+            """;
+
+        var (runResult, _) = RunGenerator(HandlerSource, behaviorSource);
+
+        runResult.Diagnostics.Should().ContainSingle(d => d.Id == "MEDL1002")
+            .Which.GetMessage().Should().Contain("AuditBehavior");
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("AuditBehavior",
+            "an unexpandable open behavior must be skipped, not emitted as non-compiling code");
+    }
+
+    [Fact]
+    public void CanonicalOpenBehavior_DoesNotReportMedl1002()
+    {
+        const string behaviorSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public sealed class PassThroughBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+                where TRequest : IRequest<TResponse>
+            {
+                public ValueTask<TResponse> HandleAsync(
+                    TRequest request,
+                    RequestHandlerDelegate<TResponse> next,
+                    CancellationToken cancellationToken = default)
+                    => next();
+            }
+            """;
+
+        var (runResult, _) = RunGenerator(HandlerSource, behaviorSource);
+
+        runResult.Diagnostics.Should().NotContain(d => d.Id == "MEDL1002");
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().Contain("PassThroughBehavior",
+            "the canonical open shape must still expand over every request type");
+    }
+
+    [Fact]
+    public void UnrelatedEdit_LeavesGeneratorOutputsCached()
+    {
+        // The pipeline models must have value equality end-to-end: an edit that does not
+        // change any discovered handler/behavior/validator must leave the output node
+        // cached instead of re-emitting both source files on every keystroke.
+        var compilation = CreateCompilation(HandlerSource);
+
+        var driver = CSharpGeneratorDriver.Create(
+            [new HandlerDiscoveryGenerator().AsSourceGenerator()],
+            driverOptions: new GeneratorDriverOptions(
+                IncrementalGeneratorOutputKind.None,
+                trackIncrementalGeneratorSteps: true));
+
+        var afterFirstRun = driver.RunGenerators(compilation);
+
+        // Simulate an unrelated edit: a new tree that declares no handler candidates.
+        var edited = compilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText("namespace DriverTests { public class Unrelated { } }"));
+
+        var secondRunResult = afterFirstRun.RunGenerators(edited)
+            .GetRunResult().Results.Single();
+
+        var outputReasons = secondRunResult.TrackedOutputSteps
+            .SelectMany(kvp => kvp.Value)
+            .SelectMany(step => step.Outputs)
+            .Select(output => output.Reason)
+            .ToList();
+
+        outputReasons.Should().NotBeEmpty();
+        outputReasons.Should().OnlyContain(
+            reason => reason == IncrementalStepRunReason.Cached || reason == IncrementalStepRunReason.Unchanged,
+            "an edit that changes no discovered model must not regenerate sources");
+    }
+
+    private static (GeneratorDriverRunResult RunResult, Compilation Compilation) RunGenerator(params string[] sources)
+    {
+        var compilation = CreateCompilation(sources);
+
+        var driver = CSharpGeneratorDriver.Create(new HandlerDiscoveryGenerator());
+        var runResult = driver.RunGenerators(compilation).GetRunResult();
+
+        return (runResult, compilation);
+    }
+
+    private static CSharpCompilation CreateCompilation(params string[] sources)
+    {
+        var referencePaths = new HashSet<string>(
+            ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+                .Split(Path.PathSeparator)
+                .Where(static path => !string.IsNullOrEmpty(path)))
+        {
+            typeof(IMediator).Assembly.Location,
+        };
+
+        return CSharpCompilation.Create(
+            "DriverTests",
+            sources.Select(static source => CSharpSyntaxTree.ParseText(
+                source,
+                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest))),
+            referencePaths.Select(static path => MetadataReference.CreateFromFile(path)),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+    }
+}

--- a/tests/MediatorLite.Tests/UnitTests/ValidationTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/ValidationTests.cs
@@ -43,5 +43,49 @@ namespace MediatorLite.Tests.UnitTests
             // The message only contains the error message, not the property name
             Assert.Contains("testMsg", ex.Message);
         }
+
+        [Fact]
+        public void ValidationException_Constructor_WithMessage_UsesMessageVerbatim()
+        {
+            var errors = new List<ValidationError> { new ValidationError("a", "b", null) };
+            var ex = new ValidationException("custom message", errors);
+
+            Assert.Equal("custom message", ex.Message);
+            Assert.Equal(errors, ex.Errors);
+        }
+
+        [Fact]
+        public void ValidationException_Message_MultipleErrors_SummarizesCount()
+        {
+            var errors = new List<ValidationError>
+            {
+                new ValidationError("p1", "first", null),
+                new ValidationError("p2", "second", null),
+            };
+            var ex = new ValidationException(errors);
+
+            Assert.Contains("2 errors", ex.Message);
+            Assert.Contains("first", ex.Message);
+            Assert.Contains("second", ex.Message);
+        }
+
+        [Fact]
+        public void ValidationException_Errors_AreFrozen_NotAffectedByLaterMutation()
+        {
+            var errors = new List<ValidationError> { new ValidationError("a", "b", null) };
+            var ex = new ValidationException(errors);
+
+            errors.Add(new ValidationError("c", "d", null));
+
+            // The exception captured a snapshot; mutating the source list does not leak in.
+            Assert.Single(ex.Errors);
+        }
+
+        [Fact]
+        public void ValidationException_NullErrors_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ValidationException((IEnumerable<ValidationError>)null!));
+            Assert.Throws<ArgumentNullException>(() => new ValidationException("msg", null!));
+        }
     }
 }


### PR DESCRIPTION
Source generator (HandlerDiscoveryGenerator):
- Dedupe discovery by fully-qualified name so partial types with base lists
  in multiple declarations register (and dispatch) once, not once per part
- Discover record-declared handlers/behaviors/validators (previously only
  ClassDeclarationSyntax, so records were silently skipped); record structs
  stay excluded since DI implementation types must be classes
- Emit one fully-typed Send_* pipeline per (request, response) pair so a
  request implementing IRequest<T> for several T dispatches each response to
  its own handler instead of throwing InvalidCastException
- Skip open generic behaviors that don't match the canonical
  Behavior<TRequest, TResponse> shape and report new MEDL1002 warning
  instead of emitting non-compiling closed types
- Restore incremental caching: model records now use EquatableArray<T>
  (value equality) instead of List<>, and the output node combines a
  projected has-FluentValidation bool instead of the raw Compilation
- Parallel + ContinueAndAggregate now rethrows a handler's
  OperationCanceledException unwrapped, matching sequential semantics
- StopOnFirst emits the success LogDebug before its early return
- Generic type names no longer produce mangled log/activity display names

Abstractions:
- ValidationException freezes Errors into an array in all ctors (no live
  List<> behind IReadOnlyList) and null-guards the errors argument
- NotificationExecution/NotificationError attributes now valid on structs
- Parallel strategy XML doc describes the actual ValueTask fan-out
  (was "Task.WhenAll")

Tests:
- Disable xUnit parallelization: fixtures share mutable statics through the
  open-generic behaviors, which raced across test classes (CI flake)
- PublishAsync_WithNoHandlers now publishes a genuinely handler-less event
  (it previously exercised a three-handler notification)
- New regression coverage: partial handler single-invocation, record
  handler dispatch, multi-response dispatch, parallel-OCE unwrap, MEDL1002
  (positive + negative), and generator output cacheability

Hooks:
- Gate scripts drain child stdout/stderr concurrently (pipe-deadlock fix)
  and fail open with a warning when the dotnet SDK is missing instead of
  crashing and hard-blocking the commit/push

Docs:
- Rules 20/60 document the emitted error-path LogError (code and rules
  contradicted each other); rules 70/80, CLAUDE.md, and docs/benchmarks.md
  stop referencing the removed RestApiBenchmarks project

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014L4JSMP56d8JfMokg7V5eR