### PR TITLE
Bug hunt: fix 7 verified defects (generator dispatch/discovery, parallel cancellation, hook SQL)

### DIFF
--- a/.agents/skills/mediatorlite-abstractions/SKILL.md
+++ b/.agents/skills/mediatorlite-abstractions/SKILL.md
@@ -444,7 +444,7 @@ public sealed class MediatorGenerationAttribute : Attribute
 }
 ```
 
-The generator still honors `[MediatorGeneration(Skip = true)]` when present (see `GetHandlerInfo`, `GetBehaviorInfo`, `GetValidatorInfo` in the generator), but **do not use it in new code**.
+The generator **ignores** `[MediatorGeneration(Skip = true)]`; discovery in `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo` is unconditional. The attribute type is kept for binary compatibility but has no effect — do not use it.
 
 #### Observability opt-outs (assembly-level, no-arg)
 

--- a/.agents/skills/mediatorlite-source-generation/SKILL.md
+++ b/.agents/skills/mediatorlite-source-generation/SKILL.md
@@ -610,7 +610,7 @@ Two generated files per compilation with handlers:
 
 ## Pitfalls & gotchas
 
-- **`[MediatorGeneration(Skip = true)]` is silently honored** in `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo`. The attribute is marked `[Obsolete]` in `Attributes.cs` but the generator still respects it — remove any usage during migrations.
+- **`[MediatorGeneration(Skip = true)]` is ignored** by `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo` — discovery is unconditional. The attribute type stays in `Attributes.cs` (marked `[Obsolete]`) for binary compatibility only; remove any usage during migrations.
 - **Validator open generics are excluded**. If you implement `MyValidator<T> : IValidator<T>`, it will **not** be auto-registered. Register it manually or make it closed.
 - **`HasDataAnnotationAttributes` only scans direct property attributes**, not fields or nested object properties. If you need nested validation, wire a custom `IValidator<T>`.
 - **Dispatcher keys use `typeof(requestType)` with the runtime type from `Mediator.SendAsync`** — abstract/base class requests are **not** registered, only closed concrete types implementing `IRequest<TResponse>` (for which a handler exists).

--- a/.agents/skills/mediatorlite-tests/SKILL.md
+++ b/.agents/skills/mediatorlite-tests/SKILL.md
@@ -333,7 +333,7 @@ public class ValidatedCommandCustomValidator : IValidator<ValidatedCommand>
 - Assert on `MediatorLiteRegistration.RequestHandlerCount` etc. whenever a PR adds a whole new category.
 
 **Don't:**
-- Don't add `[MediatorGeneration(Skip = true)]` to new test types — the attribute is obsolete (still honored for legacy compatibility, see the generator's `GetHandlerInfo`).
+- Don't add `[MediatorGeneration(Skip = true)]` to new test types — the attribute is obsolete and the generator ignores it entirely (discovery in `GetHandlerInfo` is unconditional); a "skipped" handler is registered like any other.
 - Don't share mutable instance state between handlers; use static fields + `Reset()`.
 - Don't expect dispatch without `AddGeneratedHandlers()` — without it the only `IMediator` is the [ThrowingMediator](src/MediatorLite/Internal/ThrowingMediator.cs) fallback (registered by `AddMediatorLite()`), which throws with a specific setup-guidance message on every dispatch.
 - Don't put `[NotificationExecution]` on a notification handler — the generator only reads it off the `INotification` implementation.
@@ -372,7 +372,7 @@ public class ValidatedCommandCustomValidator : IValidator<ValidatedCommand>
 
 - **Static state bleeds across tests**: xUnit creates a new instance per test but static fields persist. Always `Reset()` before acting. Parallelism at the test class level can race static state — keep handlers dedicated to one notification or guard with per-test names.
 - **Test projects target `net10.0`** (see [Directory.Build.props](Directory.Build.props)) with warnings-as-errors. Any new type that would produce a nullable-ref warning fails the build.
-- **`[MediatorGeneration(Skip = true)]` is obsolete** (documented in [Attributes.cs](src/MediatorLite.Abstractions/Abstractions/Attributes.cs)). The generator still honors it as a safety valve but never add it to new test types.
+- **`[MediatorGeneration(Skip = true)]` is obsolete and inert** (documented in [Attributes.cs](src/MediatorLite.Abstractions/Abstractions/Attributes.cs)). The generator ignores it entirely — a "skipped" handler is registered like any other. Never add it to new test types.
 - **`MediatorLiteRegistration` is generated per-assembly**. The counts reflect handlers in `MediatorLite.Tests` **only** — not downstream projects. Likewise, changing a handler in another assembly does not regenerate the tests' registration.
 - **Generator projects must be `netstandard2.0`**; test types, however, target `net10.0`. Stay on the test-assembly side when writing dependent code.
 - **`[NotificationHandlerOrder(n)]` with equal values**: order is **stable but not strictly defined** by the spec — in practice the generator orders by `OrderBy(h => h.Order ?? 0)` which preserves discovery order for ties. Do not rely on a specific tie-break.

--- a/.claude/hooks/00-save-context.csx
+++ b/.claude/hooks/00-save-context.csx
@@ -22,6 +22,14 @@ var sw = Stopwatch.StartNew();
 try
 {
     var sid = Environment.GetEnvironmentVariable("MEDIATORLITE_SESSION_ID") ?? ContextDb.EnsureSession();
+
+    // Session ids are Guid "N" strings (see ContextDb.EnsureSession), but the env var is
+    // external input: validate before it reaches a file name, and parameterize the queries
+    // below like every other query in the hook layer.
+    if (!System.Text.RegularExpressions.Regex.IsMatch(sid, "^[0-9a-fA-F-]{1,64}$"))
+        throw new InvalidOperationException(
+            $"MEDIATORLITE_SESSION_ID '{sid}' is not a valid session id; refusing to snapshot.");
+
     var snapDir = Path.Combine(Path.GetDirectoryName(ContextDb.DbPath)!, "snapshots");
     Directory.CreateDirectory(snapDir);
     var stamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ");
@@ -31,13 +39,13 @@ try
     {
         ["session_id"] = sid,
         ["taken_at"]   = DateTime.UtcNow.ToString("o"),
-        ["sessions"]   = DumpTable($"SELECT * FROM sessions WHERE id = '{sid}'"),
-        ["messages"]   = DumpTable($"SELECT * FROM agent_messages WHERE session_id = '{sid}' ORDER BY id"),
-        ["plans"]      = DumpTable($"SELECT * FROM plans WHERE session_id = '{sid}' ORDER BY id"),
-        ["decisions"]  = DumpTable($"SELECT * FROM decisions WHERE session_id = '{sid}' ORDER BY id"),
-        ["mistakes"]   = DumpTable($"SELECT * FROM mistakes WHERE session_id = '{sid}' ORDER BY id"),
-        ["reviews"]    = DumpTable($"SELECT * FROM reviews WHERE session_id = '{sid}' ORDER BY id"),
-        ["backlog"]    = DumpTable($"SELECT * FROM sprint_backlog WHERE session_id = '{sid}' ORDER BY id")
+        ["sessions"]   = DumpTable("SELECT * FROM sessions WHERE id = $sid", sid),
+        ["messages"]   = DumpTable("SELECT * FROM agent_messages WHERE session_id = $sid ORDER BY id", sid),
+        ["plans"]      = DumpTable("SELECT * FROM plans WHERE session_id = $sid ORDER BY id", sid),
+        ["decisions"]  = DumpTable("SELECT * FROM decisions WHERE session_id = $sid ORDER BY id", sid),
+        ["mistakes"]   = DumpTable("SELECT * FROM mistakes WHERE session_id = $sid ORDER BY id", sid),
+        ["reviews"]    = DumpTable("SELECT * FROM reviews WHERE session_id = $sid ORDER BY id", sid),
+        ["backlog"]    = DumpTable("SELECT * FROM sprint_backlog WHERE session_id = $sid ORDER BY id", sid)
     };
 
     File.WriteAllText(outPath, JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true }));
@@ -61,13 +69,14 @@ catch (Exception ex)
     try { ContextDb.LogHookEvent("00-save-context.csx", "beforeCompaction", "fail", sw.ElapsedMilliseconds, new { error = ex.Message }); } catch { }
 }
 
-static List<Dictionary<string, object?>> DumpTable(string sql)
+static List<Dictionary<string, object?>> DumpTable(string sql, string sid)
 {
     var rows = new List<Dictionary<string, object?>>();
     using var conn = new SqliteConnection(ContextDb.ConnectionString);
     conn.Open();
     using var cmd = conn.CreateCommand();
     cmd.CommandText = sql;
+    cmd.Parameters.AddWithValue("$sid", sid);
     using var r = cmd.ExecuteReader();
     while (r.Read())
     {

--- a/.claude/skills/mediatorlite-abstractions/SKILL.md
+++ b/.claude/skills/mediatorlite-abstractions/SKILL.md
@@ -449,7 +449,7 @@ public sealed class MediatorGenerationAttribute : Attribute
 }
 ```
 
-The generator still honors `[MediatorGeneration(Skip = true)]` when present (see `GetHandlerInfo`, `GetBehaviorInfo`, `GetValidatorInfo` in the generator), but **do not use it in new code**.
+The generator **ignores** `[MediatorGeneration(Skip = true)]`; discovery in `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo` is unconditional. The attribute type is kept for binary compatibility but has no effect — do not use it.
 
 #### Observability opt-outs (assembly-level, no-arg)
 

--- a/.claude/skills/mediatorlite-source-generation/SKILL.md
+++ b/.claude/skills/mediatorlite-source-generation/SKILL.md
@@ -616,7 +616,7 @@ Two generated files per compilation with handlers:
 
 ## Pitfalls & gotchas
 
-- **`[MediatorGeneration(Skip = true)]` is silently honored** in `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo`. The attribute is marked `[Obsolete]` in `Attributes.cs` but the generator still respects it — remove any usage during migrations.
+- **`[MediatorGeneration(Skip = true)]` is ignored** by `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo` — discovery is unconditional. The attribute type stays in `Attributes.cs` (marked `[Obsolete]`) for binary compatibility only; remove any usage during migrations.
 - **Validator open generics are excluded**. If you implement `MyValidator<T> : IValidator<T>`, it will **not** be auto-registered. Register it manually or make it closed.
 - **`HasDataAnnotationAttributes` only scans direct property attributes**, not fields or nested object properties. If you need nested validation, wire a custom `IValidator<T>`.
 - **Dispatcher keys use `typeof(requestType)` with the runtime type from `Mediator.SendAsync`** — abstract/base class requests are **not** registered, only closed concrete types implementing `IRequest<TResponse>` (for which a handler exists).

--- a/.claude/skills/mediatorlite-tests/SKILL.md
+++ b/.claude/skills/mediatorlite-tests/SKILL.md
@@ -338,7 +338,7 @@ public class ValidatedCommandCustomValidator : IValidator<ValidatedCommand>
 - Assert on `MediatorLiteRegistration.RequestHandlerCount` etc. whenever a PR adds a whole new category.
 
 **Don't:**
-- Don't add `[MediatorGeneration(Skip = true)]` to new test types — the attribute is obsolete (still honored for legacy compatibility, see the generator's `GetHandlerInfo`).
+- Don't add `[MediatorGeneration(Skip = true)]` to new test types — the attribute is obsolete and the generator ignores it entirely (discovery in `GetHandlerInfo` is unconditional); a "skipped" handler is registered like any other.
 - Don't share mutable instance state between handlers; use static fields + `Reset()`.
 - Don't expect dispatch without `AddGeneratedHandlers()` — without it the only `IMediator` is the [ThrowingMediator](src/MediatorLite/Internal/ThrowingMediator.cs) fallback (registered by `AddMediatorLite()`), which throws with a specific setup-guidance message on every dispatch.
 - Don't put `[NotificationExecution]` on a notification handler — the generator only reads it off the `INotification` implementation.
@@ -377,7 +377,7 @@ public class ValidatedCommandCustomValidator : IValidator<ValidatedCommand>
 
 - **Static state bleeds across tests**: xUnit creates a new instance per test but static fields persist. Always `Reset()` before acting. Parallelism at the test class level can race static state — keep handlers dedicated to one notification or guard with per-test names.
 - **Test projects target `net10.0`** (see [Directory.Build.props](Directory.Build.props)) with warnings-as-errors. Any new type that would produce a nullable-ref warning fails the build.
-- **`[MediatorGeneration(Skip = true)]` is obsolete** (documented in [Attributes.cs](src/MediatorLite.Abstractions/Abstractions/Attributes.cs)). The generator still honors it as a safety valve but never add it to new test types.
+- **`[MediatorGeneration(Skip = true)]` is obsolete and inert** (documented in [Attributes.cs](src/MediatorLite.Abstractions/Abstractions/Attributes.cs)). The generator ignores it entirely — a "skipped" handler is registered like any other. Never add it to new test types.
 - **`MediatorLiteRegistration` is generated per-assembly**. The counts reflect handlers in `MediatorLite.Tests` **only** — not downstream projects. Likewise, changing a handler in another assembly does not regenerate the tests' registration.
 - **Generator projects must be `netstandard2.0`**; test types, however, target `net10.0`. Stay on the test-assembly side when writing dependent code.
 - **`[NotificationHandlerOrder(n)]` with equal values**: order is **stable but not strictly defined** by the spec — in practice the generator orders by `OrderBy(h => h.Order ?? 0)` which preserves discovery order for ties. Do not rely on a specific tie-break.

--- a/.cursor/skills/mediatorlite-abstractions/SKILL.md
+++ b/.cursor/skills/mediatorlite-abstractions/SKILL.md
@@ -444,7 +444,7 @@ public sealed class MediatorGenerationAttribute : Attribute
 }
 ```
 
-The generator still honors `[MediatorGeneration(Skip = true)]` when present (see `GetHandlerInfo`, `GetBehaviorInfo`, `GetValidatorInfo` in the generator), but **do not use it in new code**.
+The generator **ignores** `[MediatorGeneration(Skip = true)]`; discovery in `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo` is unconditional. The attribute type is kept for binary compatibility but has no effect — do not use it.
 
 #### Observability opt-outs (assembly-level, no-arg)
 

--- a/.cursor/skills/mediatorlite-source-generation/SKILL.md
+++ b/.cursor/skills/mediatorlite-source-generation/SKILL.md
@@ -610,7 +610,7 @@ Two generated files per compilation with handlers:
 
 ## Pitfalls & gotchas
 
-- **`[MediatorGeneration(Skip = true)]` is silently honored** in `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo`. The attribute is marked `[Obsolete]` in `Attributes.cs` but the generator still respects it — remove any usage during migrations.
+- **`[MediatorGeneration(Skip = true)]` is ignored** by `GetHandlerInfo`, `GetBehaviorInfo`, and `GetValidatorInfo` — discovery is unconditional. The attribute type stays in `Attributes.cs` (marked `[Obsolete]`) for binary compatibility only; remove any usage during migrations.
 - **Validator open generics are excluded**. If you implement `MyValidator<T> : IValidator<T>`, it will **not** be auto-registered. Register it manually or make it closed.
 - **`HasDataAnnotationAttributes` only scans direct property attributes**, not fields or nested object properties. If you need nested validation, wire a custom `IValidator<T>`.
 - **Dispatcher keys use `typeof(requestType)` with the runtime type from `Mediator.SendAsync`** — abstract/base class requests are **not** registered, only closed concrete types implementing `IRequest<TResponse>` (for which a handler exists).

--- a/.cursor/skills/mediatorlite-tests/SKILL.md
+++ b/.cursor/skills/mediatorlite-tests/SKILL.md
@@ -333,7 +333,7 @@ public class ValidatedCommandCustomValidator : IValidator<ValidatedCommand>
 - Assert on `MediatorLiteRegistration.RequestHandlerCount` etc. whenever a PR adds a whole new category.
 
 **Don't:**
-- Don't add `[MediatorGeneration(Skip = true)]` to new test types — the attribute is obsolete (still honored for legacy compatibility, see the generator's `GetHandlerInfo`).
+- Don't add `[MediatorGeneration(Skip = true)]` to new test types — the attribute is obsolete and the generator ignores it entirely (discovery in `GetHandlerInfo` is unconditional); a "skipped" handler is registered like any other.
 - Don't share mutable instance state between handlers; use static fields + `Reset()`.
 - Don't expect dispatch without `AddGeneratedHandlers()` — without it the only `IMediator` is the [ThrowingMediator](src/MediatorLite/Internal/ThrowingMediator.cs) fallback (registered by `AddMediatorLite()`), which throws with a specific setup-guidance message on every dispatch.
 - Don't put `[NotificationExecution]` on a notification handler — the generator only reads it off the `INotification` implementation.
@@ -372,7 +372,7 @@ public class ValidatedCommandCustomValidator : IValidator<ValidatedCommand>
 
 - **Static state bleeds across tests**: xUnit creates a new instance per test but static fields persist. Always `Reset()` before acting. Parallelism at the test class level can race static state — keep handlers dedicated to one notification or guard with per-test names.
 - **Test projects target `net10.0`** (see [Directory.Build.props](Directory.Build.props)) with warnings-as-errors. Any new type that would produce a nullable-ref warning fails the build.
-- **`[MediatorGeneration(Skip = true)]` is obsolete** (documented in [Attributes.cs](src/MediatorLite.Abstractions/Abstractions/Attributes.cs)). The generator still honors it as a safety valve but never add it to new test types.
+- **`[MediatorGeneration(Skip = true)]` is obsolete and inert** (documented in [Attributes.cs](src/MediatorLite.Abstractions/Abstractions/Attributes.cs)). The generator ignores it entirely — a "skipped" handler is registered like any other. Never add it to new test types.
 - **`MediatorLiteRegistration` is generated per-assembly**. The counts reflect handlers in `MediatorLite.Tests` **only** — not downstream projects. Likewise, changing a handler in another assembly does not regenerate the tests' registration.
 - **Generator projects must be `netstandard2.0`**; test types, however, target `net10.0`. Stay on the test-assembly side when writing dependent code.
 - **`[NotificationHandlerOrder(n)]` with equal values**: order is **stable but not strictly defined** by the spec — in practice the generator orders by `OrderBy(h => h.Order ?? 0)` which preserves discovery order for ties. Do not rely on a specific tie-break.

--- a/.github/Lessons/2026-07-12-generator-discovery-guards-must-be-shared.md
+++ b/.github/Lessons/2026-07-12-generator-discovery-guards-must-be-shared.md
@@ -1,0 +1,41 @@
+# Lesson: Generator Discovery Guards Must Be Shared Across Every Pipeline
+
+## Metadata
+- PatternId: generator-discovery-guards-must-be-shared
+- PatternVersion: 1
+- Status: active
+- Supersedes:
+- CreatedAt: 2026-07-12
+- LastValidatedAt: 2026-07-12
+- ValidationEvidence: `SourceGeneratorDriverTests.GenericHandlerClass_WithClosedInterface_ReportsMedl1004_AndIsNotEmitted`, `OpenGenericHandlers_ReportMedl1004_AndAreNotEmitted`, `HandlerNestedInGenericOuterType_ReportsMedl1004_AndIsNotEmitted`, `BehaviorNestedInGenericOuterType_ReportsMedl1002_AndIsNotEmitted` (each fails on the pre-fix generator — no diagnostic, non-compiling `.g.cs` — and passes after); full suite 125/125; clean `dotnet build MediatorLite.sln -c Release` with warnings-as-errors.
+
+## Task Context
+- Triggering task: Repo-wide adversarial bug hunt. The generator reviewer flagged that `GetHandlerInfo` had no generic-type guard even though `GetValidatorInfo` skipped `IsGenericType` and `GetBehaviorInfo` reported MEDL1002 — so generic handlers emitted unbound type parameters and broke the consumer's build.
+- Date/time: 2026-07-12
+- Impacted area: `src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs` — the four discovery transforms (`GetHandlerInfo`, `GetBehaviorInfo`, `GetValidatorInfo`, and the notification handler path inside `GetHandlerInfo`).
+
+## Mistake
+- What went wrong: Each discovery pipeline grew its own "is this type emittable?" check independently, and each had a *different* hole:
+  1. `GetHandlerInfo` (request + notification handlers) had **no** guard at all — a generic handler class, an open generic handler (`IRequestHandler<TReq, TRes>`), or a handler nested inside a generic outer type had its fully-qualified display name (carrying unbound type parameters) pasted into the generated registration and dispatch switch.
+  2. `GetValidatorInfo` guarded with `classSymbol.IsGenericType`, which catches a generic *class* but **not** a non-generic validator nested inside a generic outer type (`Outer<T>.InnerValidator`), whose display name still carries `T`.
+  3. `GetBehaviorInfo` / `IsSupportedOpenShape` checked only the class's own `TypeParameters`, so a closed-interface behavior nested in a generic outer type slipped through, and the open-shape path additionally truncated the display name at the outer type's `<`, emitting the wrong type name entirely.
+- Expected behavior: Any type whose fully-qualified name would contain an unbound type parameter is excluded from emission and surfaced as a diagnostic (MEDL1002 for behaviors, new MEDL1004 for handlers), never emitted as non-compiling code.
+- Actual behavior: Generic/nested-generic handlers emitted `case TReq r_TReq:` and `Ns.Handler<TUnused>` registrations, breaking the *consumer's* build with CS0246/CS0103 inside a `.g.cs` file they cannot edit — with no diagnostic pointing at the cause.
+
+## Root Cause Analysis
+- Primary cause: The invariant "an emitted type's display name must contain no unbound type parameter" is identical for handlers, behaviors, and validators, but it was expressed three times, three different ways, by whoever last touched each pipeline. Copy-drift guaranteed the guards diverged.
+- Contributing factors: `INamedTypeSymbol.IsGenericType` reads as "covers generics" but only inspects the type itself, not its containing-type chain — a subtle gap that looks correct in review. The behavior path's openness check was written for the interface arguments, so nobody thought to also check the *containing* type.
+- Detection gap: No driver test drove the generator with a generic or nested-in-generic handler/behavior/validator and asserted the output compiles; the existing MEDL1002 tests only covered the class's own type parameters.
+
+## Resolution
+- Fix implemented: Added one shared helper, `HasTypeParametersInScope(INamedTypeSymbol)`, that walks the `ContainingType` chain and returns true if the type *or any enclosing type* declares type parameters. All three discovery pipelines now use it: `GetHandlerInfo` flags such classes and `Execute` reports the new warning **MEDL1004** and excludes them; `GetBehaviorInfo`/`IsSupportedOpenShape` reject nested-in-generic types into the existing MEDL1002; `GetValidatorInfo` replaces its `IsGenericType` check with the shared helper.
+- Why this fix works: A single predicate expresses the invariant once, so the three pipelines cannot drift again; walking the containing-type chain closes the nested-generic hole that `IsGenericType` and the own-`TypeParameters`-only checks both missed.
+- Verification performed: The four driver tests above (each fails on the pre-fix generator, passes after), plus the full suite and a warnings-as-errors Release build.
+
+## Preventive Actions
+- Guardrails added: `HasTypeParametersInScope` carries a doc comment stating it is *the* emittability guard and why the containing-type chain matters; MEDL1004 registered in `AnalyzerReleases.Unshipped.md`.
+- Tests/checks added: `SourceGeneratorDriverTests` gained four tests spanning generic class, open generic handler, handler-nested-in-generic, and behavior-nested-in-generic, each asserting the diagnostic is present AND `AssertGeneratedOutputCompiles`.
+- Process updates: Any new discovery pipeline (rule `20-source-generator.md`) that emits a type's display name MUST route the candidate through `HasTypeParametersInScope` and skip-with-diagnostic on a true result — never add a bespoke `IsGenericType`/`TypeParameters.Length` check.
+
+## Reuse Guidance
+- How to apply this lesson in future tasks: When a generator has parallel discovery/emission paths that share an invariant (here: "no unbound type parameter in the emitted name"), express the invariant as one shared predicate and call it from every path — divergent copies are where the holes hide. Whenever you emit `ITypeSymbol.ToDisplayString(FullyQualifiedFormat)`, ask "could this contain a type parameter?" and remember that `IsGenericType` does not account for nesting inside a generic type. Every emittability guard needs a driver test that asserts the generated output actually compiles, not just that a diagnostic fires.

--- a/.github/Memories/mediatorgeneration-skip-attribute-inert.md
+++ b/.github/Memories/mediatorgeneration-skip-attribute-inert.md
@@ -1,0 +1,28 @@
+# Memory: `[MediatorGeneration(Skip = true)]` Is Inert — Discovery Is Unconditional
+
+## Metadata
+- PatternId: mediatorgeneration-skip-inert
+- PatternVersion: 1
+- Status: active
+- Supersedes:
+- CreatedAt: 2026-07-12
+- LastValidatedAt: 2026-07-12
+- ValidationEvidence: `SourceGeneratorDriverTests.ObsoleteMediatorGenerationSkip_IsIgnored_HandlerIsStillDiscovered` (a `Skip = true` handler appears in generated registration; the test failed while the generator still honored the attribute); full suite green.
+
+## Source Context
+- Triggering task: Repo-wide bug hunt found the generator still honoring `[MediatorGeneration(Skip = true)]` in all three discovery pipelines while rule `70-testing.md` §3 documented v2 discovery as unconditional — a docs/code contradiction either side could be burned by.
+- Scope/system: Source generator discovery (`GetHandlerInfo` / `GetBehaviorInfo` / `GetValidatorInfo` in `HandlerDiscoveryGenerator.cs`), consumer docs (`README.md`, `docs/quick-start.md`, `docs/migration-from-mediatr.md`, `docs/migration-v1-to-v2.md`).
+- Date/time: 2026-07-12
+
+## Memory
+- Key fact or decision: **The generator ignores `[MediatorGeneration(Skip = true)]` entirely.** Discovery is unconditional for every concrete handler, behavior, and validator in the compilation. The decision (made explicitly by the project owner, choosing code-matches-docs over docs-match-code) removed the three `hasSkipAttribute` checks. The attribute **type** stays in `MediatorLite.Abstractions` with its `[Obsolete]` marking — rule 90 §4 treats obsolete symbols as public-API contract — but it has no behavioral effect.
+- Why it matters: This is a rule-90 §3 breaking change (attribute semantics changed). Any consumer who used `Skip = true` while suppressing the obsolete warning will see that handler registered after upgrading. The supported exclusion mechanism is structural: put the type in an assembly the generator does not run on.
+
+## Applicability
+- When to reuse: Reviewing PRs that try to reintroduce a per-type opt-out; answering "why is my Skip handler suddenly registered?"; any future proposal for conditional discovery (needs an ADR and a very good reason — conditional discovery is the runtime-configuration sprawl v2 deleted).
+- Preconditions/limitations: The attribute type itself must not be deleted outside a major-version bump (rule 90 §4).
+
+## Actionable Guidance
+- Recommended future action: If a genuine exclusion need appears, prefer a documented structural convention (separate assembly) over resurrecting the attribute. If the attribute type is ever removed, that is a second, separate rule-90 §3 break.
+- Related files/services/components: `src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs` (discovery pipelines), `src/MediatorLite.Abstractions/Abstractions/Attributes.cs` (`MediatorGenerationAttribute`), `docs/migration-v1-to-v2.md` (migration note), `.claude/rules/70-testing.md` §3.
+- Related memory: `medl1002-open-behavior-shape` — same subsystem; that memory defines which behavior shapes are discoverable, this one pins that discoverable shapes cannot opt out.

--- a/README.md
+++ b/README.md
@@ -195,15 +195,10 @@ services.AddMediatorLite();  // Without AddGeneratedHandlers(), dispatch throws 
 
 #### Excluding Types from Source Generation
 
-Use `[MediatorGeneration(Skip = true)]` to exclude specific handlers from source-generated discovery:
-
-```csharp
-[MediatorGeneration(Skip = true)]
-public class TestOnlyHandler : IRequestHandler<TestQuery, string>
-{
-    // This handler will NOT be registered by AddGeneratedHandlers()
-}
-```
+Discovery is unconditional: every concrete handler in the compilation is registered. The
+legacy `[MediatorGeneration(Skip = true)]` attribute is obsolete and has **no effect**. To
+keep a handler out of registration, move it to an assembly the source generator does not
+run on (for example, a test-support project).
 
 ### 3. Send Requests
 

--- a/docs/migration-from-mediatr.md
+++ b/docs/migration-from-mediatr.md
@@ -313,15 +313,9 @@ The source-generated mediator provides:
 
 ### Excluding Types
 
-Use `[MediatorGeneration(Skip = true)]` to exclude a type from source generation:
-
-```csharp
-[MediatorGeneration(Skip = true)]
-public class TestHandler : IRequestHandler<TestQuery, string>
-{
-    // Not registered by AddGeneratedHandlers()
-}
-```
+Discovery is unconditional — there is no per-type opt-out attribute (the legacy
+`[MediatorGeneration(Skip = true)]` is obsolete and has no effect). To exclude a type from
+registration, move it to an assembly the source generator does not run on.
 
 ### Diagnostics
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -216,9 +216,12 @@ public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TReques
 public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> { }
 ```
 
-#### `[MediatorGeneration(Skip = true)]` - Obsolete
+#### `[MediatorGeneration(Skip = true)]` - Obsolete and Inert
 
-This attribute is obsolete in v2 and is retained only for legacy compatibility. Avoid using it for new code.
+The attribute type is retained for binary compatibility, but the v2 generator **ignores
+it**: discovery is unconditional, so a handler marked `Skip = true` is registered like any
+other. If you relied on `Skip` to keep a handler out of registration, move that handler to
+an assembly the source generator does not run on (for example, a test-support project).
 
 ### Step 5: Verify Generated Code
 
@@ -288,11 +291,12 @@ services.AddLogging(b => b.AddFilter("MediatorLite.IMediator", LogLevel.Informat
 
 ### Issue: Handlers Not Discovered
 
-**Cause:** Handler marked with `[MediatorGeneration(Skip = true)]` or not implementing correct interface.
+**Cause:** Handler not implementing the correct interface, or the handler is generic /
+nested inside a generic type (surfaced as warning `MEDL1004`).
 
-**Fix:** 
-1. Remove `[MediatorGeneration(Skip = true)]` or register manually
-2. Verify handler implements `IRequestHandler<TRequest, TResponse>`
+**Fix:**
+1. Verify the handler implements `IRequestHandler<TRequest, TResponse>`
+2. Make the handler a non-generic class that is not nested inside a generic type
 
 ### Issue: Behaviors Executing in Wrong Order
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -128,16 +128,10 @@ services.AddMediatorLite();  // Without AddGeneratedHandlers(), dispatch throws 
 
 ### Excluding Types from Source Generation
 
-Use `[MediatorGeneration(Skip = true)]` to prevent a handler from being discovered by the source generator:
-
-```csharp
-[MediatorGeneration(Skip = true)]
-public class TestOnlyHandler : IRequestHandler<TestQuery, string>
-{
-    // This handler will NOT be registered by AddGeneratedHandlers()
-    // Register it manually if needed
-}
-```
+Discovery is unconditional: every concrete handler in the compilation is registered. The
+legacy `[MediatorGeneration(Skip = true)]` attribute is obsolete and has **no effect**. To
+keep a handler out of registration, move it to an assembly the source generator does not
+run on (for example, a test-support project).
 
 ## 3. Send Requests
 

--- a/src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md
+++ b/src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 MEDL1001 | MediatorLite.Validation | Error | FluentValidation validators were found but the MediatorLite.FluentValidation package is not referenced.
 MEDL1002 | MediatorLite.Behaviors | Warning | An open generic pipeline behavior does not match the supported Behavior<TRequest, TResponse> shape and was not registered.
 MEDL1003 | MediatorLite.Handlers | Warning | Multiple handlers are registered for the same (request, response) pair; only the last registration is invoked at dispatch time.
+MEDL1004 | MediatorLite.Handlers | Warning | A handler class is generic or nested inside a generic type and cannot be registered by the source generator.

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -1727,6 +1727,11 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         List<(HandlerInfo Handler, NotificationHandlerInterfaceInfo Interface)> handlers,
         int errorStrategy)
     {
+        // An already-cancelled publish token must be rejected before any handler starts,
+        // matching the entry check every other execution strategy performs. In-flight
+        // cancellation stays cooperative (handlers observe the token themselves).
+        sb.AppendLine("            ct.ThrowIfCancellationRequested();");
+
         // Resolve handlers
         for (int i = 0; i < handlers.Count; i++)
         {

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -819,6 +819,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             .SelectMany(h => h.RequestHandlers.Select(r => (r.RequestType, r.ResponseType!)))
             .Distinct()
             .ToList();
+        var handledPairs = new HashSet<(string, string)>(requestResponsePairs);
 
         foreach (var behavior in behaviors)
         {
@@ -848,6 +849,12 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 }
                 else if (!behaviorInterface.IsOpenGeneric)
                 {
+                    // A closed behavior bound to a (request, response) pair with no handler
+                    // in this compilation has no pipeline to run in — registering it would
+                    // be dead wiring and inflate BehaviorCount. Same policy as validators.
+                    if (!handledPairs.Contains((behaviorInterface.RequestType!, behaviorInterface.ResponseType!)))
+                        continue;
+
                     expanded.Add(new ExpandedBehaviorInfo(
                         BehaviorTypeName: behavior.ClassName,
                         RequestType: behaviorInterface.RequestType!,

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -492,6 +492,11 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (hasSkipAttribute)
             return null;
 
+        // A validator class may implement IValidator<T> for several request types; collect
+        // every match — stopping at the first would silently leave the remaining request
+        // types unvalidated.
+        List<ValidatorTargetInfo>? targets = null;
+
         foreach (var iface in classSymbol.AllInterfaces)
         {
             if (!iface.IsGenericType)
@@ -514,14 +519,18 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             if (typeArgs[0].TypeKind == TypeKind.TypeParameter)
                 continue;
 
-            return new ValidatorInfo(
-                ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
+            (targets ??= []).Add(new ValidatorTargetInfo(
                 InterfaceType: iface.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                RequestType: typeArgs[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                RequestType: typeArgs[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
         }
 
-        return null;
+        if (targets is null)
+            return null;
+
+        return new ValidatorInfo(
+            ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
+            Targets: new EquatableArray<ValidatorTargetInfo>(targets.ToArray()));
     }
 
     /// <summary>
@@ -778,7 +787,8 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         List<ValidatorInfo> validators)
     {
         var result = new List<(string RequestType, string ResponseType)>();
-        var requestTypesWithValidators = new HashSet<string>(validators.Select(v => v.RequestType));
+        var requestTypesWithValidators = new HashSet<string>(
+            validators.SelectMany(v => v.Targets).Select(t => t.RequestType));
 
         var requestResponsePairs = handlers
             .SelectMany(h => h.RequestHandlers.Select(r => (r.RequestType, ResponseType: r.ResponseType!)))
@@ -1030,17 +1040,19 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
 
         // Register discovered FluentValidation validators against their FluentValidation.IValidator<T>
         // service type so FluentValidationBehavior<T,_> can resolve them. No assembly scanning.
-        // Only validators whose request type has a generated pipeline (i.e. a handler in this
-        // compilation) are registered: a validator for an unhandled request type is never resolved,
-        // so registering it would be dead wiring (and could reference inaccessible types).
+        // A class registers once per IValidator<T> it implements. Only registrations whose
+        // request type has a generated pipeline (i.e. a handler in this compilation) are
+        // emitted: a validator for an unhandled request type is never resolved, so
+        // registering it would be dead wiring (and could reference inaccessible types).
         var validatedRequestTypes = new HashSet<string>(requestTypesWithValidation.Select(t => t.RequestType));
-        var validatorsToRegister = validators
-            .Where(v => validatedRequestTypes.Contains(v.RequestType))
+        var validatorRegistrations = validators
+            .SelectMany(v => v.Targets.Select(t => (v.ClassName, t.InterfaceType, t.RequestType)))
+            .Where(r => validatedRequestTypes.Contains(r.RequestType))
             .ToList();
 
-        foreach (var validator in validatorsToRegister)
+        foreach (var (className, interfaceType, _) in validatorRegistrations)
         {
-            sb.AppendLine($"            services.AddTransient<{validator.InterfaceType}, {validator.ClassName}>();");
+            sb.AppendLine($"            services.AddTransient<{interfaceType}, {className}>();");
         }
 
         sb.AppendLine("            return services;");
@@ -1091,7 +1103,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         // --- Diagnostic counts ---
-        var totalValidatorCount = validatorsToRegister.Count;
+        var totalValidatorCount = validatorRegistrations.Count;
         var nonValidationBehaviorCount = expandedBehaviors
             .Count(b => !b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<"));
 
@@ -1952,5 +1964,8 @@ internal sealed record ExpandedBehaviorInfo(
 internal sealed record ValidatorInfo(
     string ClassName,
     string Namespace,
+    EquatableArray<ValidatorTargetInfo> Targets);
+
+internal sealed record ValidatorTargetInfo(
     string InterfaceType,
     string RequestType);

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -76,6 +76,22 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Reported when a handler class is generic or nested inside a generic type. Its
+    /// fully-qualified name contains unbound type parameters, so emitting it into the
+    /// generated registration/dispatch would produce code that fails to compile (CS0246)
+    /// inside a .g.cs file. The handler is skipped and surfaced here instead.
+    /// </summary>
+    private static readonly DiagnosticDescriptor UnsupportedGenericHandler = new(
+        id: "MEDL1004",
+        title: "Generic handler classes are not supported",
+        messageFormat: "Handler '{0}' is generic or nested inside a generic type, so the source "
+            + "generator cannot emit a closed registration for it; the handler was not registered. "
+            + "Make the handler a non-generic class that is not nested inside a generic type.",
+        category: "MediatorLite.Handlers",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Find all class declarations that might be handlers
@@ -322,10 +338,12 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                     //    would emit `Wrap<T>` with T unbound;
                     //  - a generic class whose interface is fully closed
                     //    (Behavior<TUnused> : IPipelineBehavior<Req, Res>) would emit the
-                    //    class display name `Behavior<TUnused>` with TUnused unbound.
-                    // Both produce CS0246 in the generated files, so they get MEDL1002 too.
+                    //    class display name `Behavior<TUnused>` with TUnused unbound —
+                    //    the same applies when the behavior is nested inside a generic
+                    //    type (Outer<T>.Inner), hence HasTypeParametersInScope.
+                    // All produce CS0246 in the generated files, so they get MEDL1002 too.
                     if (!isInterfaceOpen
-                        && (typeArgs.Any(ContainsTypeParameter) || classSymbol.TypeParameters.Length > 0))
+                        && (typeArgs.Any(ContainsTypeParameter) || HasTypeParametersInScope(classSymbol)))
                     {
                         hasUnsupportedOpenShape = true;
                         continue;
@@ -372,6 +390,12 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (classSymbol.TypeParameters.Length != 2)
             return false;
 
+        // A behavior nested inside a generic type cannot be expanded: its display name is
+        // truncated at the *first* '<' (the outer type's), so the emitted closed type would
+        // name the outer type instead of the behavior.
+        if (classSymbol.ContainingType is { } containing && HasTypeParametersInScope(containing))
+            return false;
+
         var requestParam = classSymbol.TypeParameters[0];
         var responseParam = classSymbol.TypeParameters[1];
 
@@ -408,6 +432,28 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
     }
 
     /// <summary>
+    /// Whether the type — or any type it is nested inside — declares type parameters. The
+    /// fully-qualified display string of such a type contains those parameters (e.g.
+    /// <c>Handler&lt;TUnused&gt;</c> or <c>Outer&lt;T&gt;.Inner</c>), so emitting it into the
+    /// generated registration or dispatch produces unbound identifiers (CS0246). Discovery
+    /// must skip these types (surfacing a diagnostic) instead of emitting broken code.
+    /// Checked explicitly across the containing-type chain rather than relying on
+    /// <c>INamedTypeSymbol.IsGenericType</c> semantics.
+    /// </summary>
+    private static bool HasTypeParametersInScope(INamedTypeSymbol symbol)
+    {
+        for (INamedTypeSymbol? current = symbol; current is not null; current = current.ContainingType)
+        {
+            if (current.TypeParameters.Length > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Whether a type parameter occurs anywhere inside <paramref name="type"/> — not just at
     /// the top level. Emitting any type that still contains a type parameter into the generated
     /// registration or pipeline produces unbound identifiers (CS0246), so such shapes must be
@@ -433,8 +479,10 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (classSymbol is null || classSymbol.IsAbstract || !classSymbol.IsReferenceType)
             return null;
 
-        // Skip open generic validators (e.g., a user's own generic AbstractValidator<T>)
-        if (classSymbol.IsGenericType)
+        // Skip generic validators (e.g., a user's own generic AbstractValidator<T>) and
+        // validators nested inside generic types — their display names carry unbound type
+        // parameters and cannot be emitted.
+        if (HasTypeParametersInScope(classSymbol))
             return null;
 
         var hasSkipAttribute = classSymbol.GetAttributes()
@@ -592,6 +640,20 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (requestHandlerInterfaces.Count == 0 && notificationHandlerInterfaces.Count == 0)
             return null;
 
+        // A generic handler (or one nested inside a generic type) cannot be emitted: its
+        // display name carries unbound type parameters, producing CS0246 in the generated
+        // files. Keep the class name for the MEDL1004 report but carry no interfaces so
+        // nothing downstream registers or dispatches it.
+        if (HasTypeParametersInScope(classSymbol))
+        {
+            return new HandlerInfo(
+                ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
+                RequestHandlers: new EquatableArray<HandlerInterfaceInfo>([]),
+                NotificationHandlers: new EquatableArray<NotificationHandlerInterfaceInfo>([]),
+                HasUnsupportedGenericShape: true);
+        }
+
         return new HandlerInfo(
             ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
@@ -622,6 +684,14 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             context.ReportDiagnostic(Diagnostic.Create(
                 UnsupportedOpenBehaviorShape, Location.None, StripGlobalPrefix(behavior.ClassName)));
         }
+
+        foreach (var handler in validHandlers.Where(h => h.HasUnsupportedGenericShape))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                UnsupportedGenericHandler, Location.None, StripGlobalPrefix(handler.ClassName)));
+        }
+
+        validHandlers = validHandlers.Where(h => !h.HasUnsupportedGenericShape).ToList();
 
         if (validHandlers.Count == 0)
         {
@@ -1821,7 +1891,8 @@ internal sealed record HandlerInfo(
     string ClassName,
     string Namespace,
     EquatableArray<HandlerInterfaceInfo> RequestHandlers,
-    EquatableArray<NotificationHandlerInterfaceInfo> NotificationHandlers);
+    EquatableArray<NotificationHandlerInterfaceInfo> NotificationHandlers,
+    bool HasUnsupportedGenericShape = false);
 
 internal sealed record HandlerInterfaceInfo(
     string InterfaceType,

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -293,13 +293,6 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (classSymbol is null || classSymbol.IsAbstract || !classSymbol.IsReferenceType)
             return null;
 
-        var hasSkipAttribute = classSymbol.GetAttributes()
-            .Any(a => IsMediatorLiteAttribute(a, "MediatorGenerationAttribute")
-                      && a.NamedArguments.Any(arg => arg.Key == "Skip" && arg.Value.Value is true));
-
-        if (hasSkipAttribute)
-            return null;
-
         var behaviorInterfaces = new List<BehaviorInterfaceInfo>();
         bool isOpenGeneric = classSymbol.IsGenericType && classSymbol.IsUnboundGenericType == false
                              && classSymbol.TypeParameters.Length > 0;
@@ -485,13 +478,6 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (HasTypeParametersInScope(classSymbol))
             return null;
 
-        var hasSkipAttribute = classSymbol.GetAttributes()
-            .Any(a => IsMediatorLiteAttribute(a, "MediatorGenerationAttribute")
-                      && a.NamedArguments.Any(arg => arg.Key == "Skip" && arg.Value.Value is true));
-
-        if (hasSkipAttribute)
-            return null;
-
         // A validator class may implement IValidator<T> for several request types; collect
         // every match — stopping at the first would silently leave the remaining request
         // types unvalidated.
@@ -586,13 +572,6 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         var classSymbol = semanticModel.GetDeclaredSymbol(typeDecl, ct) as INamedTypeSymbol;
 
         if (classSymbol is null || classSymbol.IsAbstract || !classSymbol.IsReferenceType)
-            return null;
-
-        var hasSkipAttribute = classSymbol.GetAttributes()
-            .Any(a => IsMediatorLiteAttribute(a, "MediatorGenerationAttribute")
-                      && a.NamedArguments.Any(arg => arg.Key == "Skip" && arg.Value.Value is true));
-
-        if (hasSkipAttribute)
             return null;
 
         int? handlerOrder = null;

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -1290,11 +1290,15 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 }
 
                 sb.AppendLine("                    // Covariant dispatch (IRequest<out T>): pick the pipeline whose concrete");
-                sb.AppendLine("                    // response type is assignable to the requested TResponse.");
+                sb.AppendLine("                    // response type is assignable to the requested TResponse. Value-type");
+                sb.AppendLine("                    // responses are excluded: variance only exists for reference conversions,");
+                sb.AppendLine("                    // so an IRequest<TResponse> reference can never originate from a");
+                sb.AppendLine("                    // value-type response interface — but IsAssignableTo alone would match");
+                sb.AppendLine("                    // one via boxing and silently run the wrong pipeline.");
                 foreach (var (_, iface) in group.Entries)
                 {
                     var sendName = $"Send_{sendMethodSuffixes[(group.RequestType, iface.ResponseType!)]}";
-                    sb.AppendLine($"                    if (typeof({iface.ResponseType}).IsAssignableTo(typeof(TResponse)))");
+                    sb.AppendLine($"                    if (!typeof({iface.ResponseType}).IsValueType && typeof({iface.ResponseType}).IsAssignableTo(typeof(TResponse)))");
                     sb.AppendLine("                    {");
                     sb.AppendLine($"                        return SlowCast<{iface.ResponseType}, TResponse>({sendName}(r_{safeName}, cancellationToken));");
                     sb.AppendLine("                    }");

--- a/src/MediatorLite.SourceGeneration/README.md
+++ b/src/MediatorLite.SourceGeneration/README.md
@@ -150,15 +150,10 @@ services
 
 ### Excluding Types from Source Generation
 
-Use `[MediatorGeneration(Skip = true)]` to exclude specific handlers:
-
-```csharp
-[MediatorGeneration(Skip = true)]
-public class TestOnlyHandler : IRequestHandler<TestQuery, string>
-{
-    // This handler will NOT be registered by AddGeneratedHandlers()
-}
-```
+Discovery is unconditional: every concrete handler in the compilation is registered. The
+legacy `[MediatorGeneration(Skip = true)]` attribute is obsolete and has **no effect**. To
+keep a handler out of registration, move it to an assembly the source generator does not
+run on (for example, a test-support project).
 
 ### Configurable Handler Execution (v2 Attributes)
 

--- a/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
@@ -325,4 +325,30 @@ public class MediatorTests
         arrayResult.Should().Equal(0, 1, 2);
         stringResult.Should().Be("count:3");
     }
+
+    [Fact]
+    public async Task SendAsync_CovariantMultiResponseRequest_PicksVarianceCompatiblePipeline()
+    {
+        // Arrange - MultiResponseQuery implements IRequest<int> and IRequest<string>. An
+        // IRequest<object> reference can only exist through the string interface, because
+        // IRequest<out T> variance never applies to value types (IRequest<int> is not an
+        // IRequest<object>). Dispatch must therefore pick the string pipeline. The int
+        // pipeline used to win because the emitted fallback tested
+        // typeof(int).IsAssignableTo(typeof(object)), which is true via boxing — returning
+        // a boxed 50 instead of "value:5" with no error.
+        var services = new ServiceCollection();
+        services.AddGeneratedHandlers();
+        services.AddMediatorLite();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        // Act
+        IRequest<object> request = new MultiResponseQuery(5);
+        var result = await mediator.SendAsync(request);
+
+        // Assert
+        result.Should().Be("value:5");
+    }
 }

--- a/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/MediatorTests.cs
@@ -26,7 +26,7 @@ public class MediatorTests
     [Fact]
     public void AddGeneratedHandlers_RegistersNotificationHandlers()
     {
-        MediatorLiteRegistration.NotificationHandlerCount.Should().Be(24,
+        MediatorLiteRegistration.NotificationHandlerCount.Should().Be(26,
             "the source generator must discover every notification handler in TestTypes.cs");
     }
 

--- a/tests/MediatorLite.Tests/SourceGeneration/NotificationTests.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/NotificationTests.cs
@@ -299,6 +299,36 @@ public class NotificationTests
     }
 
     [Fact]
+    public async Task PublishAsync_Parallel_WithPreCancelledToken_ThrowsOceWithoutRunningHandlers()
+    {
+        // Arrange - the handlers are ct-agnostic, so only the mediator's own entry check can
+        // reject the pre-cancelled token. Sequential/StopOnFirst already did; Parallel used to
+        // run every handler to completion and report success.
+        ParallelPreCancelHandler1.Reset();
+        ParallelPreCancelHandler2.Reset();
+
+        var services = new ServiceCollection();
+        services.AddGeneratedHandlers();
+        services.AddMediatorLite();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        Func<Task> act = async () => await mediator.PublishAsync(new ParallelPreCancelEvent("x"), cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        ParallelPreCancelHandler1.WasCalled.Should().BeFalse(
+            "no handler may start under an already-cancelled publish token");
+        ParallelPreCancelHandler2.WasCalled.Should().BeFalse(
+            "no handler may start under an already-cancelled publish token");
+    }
+
+    [Fact]
     public async Task PublishAsync_PerNotificationAttribute_WinsOverLibraryDefaults()
     {
         // Arrange - UserCreatedEvent has no per-type attribute, so it falls back to library defaults

--- a/tests/MediatorLite.Tests/SourceGeneration/TestTypes.cs
+++ b/tests/MediatorLite.Tests/SourceGeneration/TestTypes.cs
@@ -736,3 +736,38 @@ public sealed class SequentialCancellingSecondHandler : INotificationHandler<Seq
 }
 
 #endregion
+
+#region Parallel pre-cancelled token fixtures (B3)
+
+// Parallel publishing must reject an already-cancelled publish token before starting any
+// handler, matching the Sequential/StopOnFirst entry check. These handlers are deliberately
+// ct-agnostic and synchronous so the only cancellation check in play is the mediator's own.
+[NotificationExecution(NotificationExecutionStrategy.Parallel)]
+public record ParallelPreCancelEvent(string Message) : INotification;
+
+public sealed class ParallelPreCancelHandler1 : INotificationHandler<ParallelPreCancelEvent>
+{
+    public static bool WasCalled { get; private set; }
+    public static void Reset() => WasCalled = false;
+
+    public ValueTask HandleAsync(ParallelPreCancelEvent notification, CancellationToken cancellationToken = default)
+    {
+        WasCalled = true;
+        return ValueTask.CompletedTask;
+    }
+}
+
+[NotificationHandlerOrder(1)]
+public sealed class ParallelPreCancelHandler2 : INotificationHandler<ParallelPreCancelEvent>
+{
+    public static bool WasCalled { get; private set; }
+    public static void Reset() => WasCalled = false;
+
+    public ValueTask HandleAsync(ParallelPreCancelEvent notification, CancellationToken cancellationToken = default)
+    {
+        WasCalled = true;
+        return ValueTask.CompletedTask;
+    }
+}
+
+#endregion

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -666,6 +666,38 @@ public class SourceGeneratorDriverTests
     }
 
     [Fact]
+    public void ObsoleteMediatorGenerationSkip_IsIgnored_HandlerIsStillDiscovered()
+    {
+        // v2 discovery is unconditional (rule 70 §3). The obsolete
+        // [MediatorGeneration(Skip = true)] must have no effect on the generator; consumers
+        // who need to exclude a type move it to a non-compiled assembly instead.
+        const string source = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public record SkippedQuery(int Value) : IRequest<int>;
+
+            #pragma warning disable CS0618 // MediatorGenerationAttribute is obsolete
+            [MediatorGeneration(Skip = true)]
+            #pragma warning restore CS0618
+            public sealed class SkippedQueryHandler : IRequestHandler<SkippedQuery, int>
+            {
+                public ValueTask<int> HandleAsync(SkippedQuery request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(request.Value);
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, source);
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().Contain("SkippedQueryHandler",
+            "discovery is unconditional: the obsolete [MediatorGeneration(Skip = true)] has no effect");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
     public void ClosedBehaviorForUnhandledRequestType_IsNotRegisteredOrCounted()
     {
         // A closed behavior bound to a request type with no handler in the compilation can

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -666,6 +666,40 @@ public class SourceGeneratorDriverTests
     }
 
     [Fact]
+    public void ClosedBehaviorForUnhandledRequestType_IsNotRegisteredOrCounted()
+    {
+        // A closed behavior bound to a request type with no handler in the compilation can
+        // never be resolved by any generated pipeline. It used to be registered in DI and
+        // counted in BehaviorCount anyway (dead wiring), while validators in the same
+        // situation were filtered out — the policies now match.
+        const string source = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public record RetiredCommand(int Id) : IRequest<int>;
+
+            public sealed class RetiredAuditBehavior : IPipelineBehavior<RetiredCommand, int>
+            {
+                public ValueTask<int> HandleAsync(
+                    RetiredCommand request,
+                    RequestHandlerDelegate<int> next,
+                    CancellationToken cancellationToken = default)
+                    => next();
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, source);
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("RetiredAuditBehavior",
+            "a closed behavior whose request type has no handler can never run and must not be wired");
+        generated.Should().Contain("public static int BehaviorCount => 0;");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
     public void ValidatorImplementingMultipleValidatorInterfaces_WiresValidationForEveryRequestType()
     {
         // One validator class may validate several request types (IValidator<A> +

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -666,6 +666,67 @@ public class SourceGeneratorDriverTests
     }
 
     [Fact]
+    public void ValidatorImplementingMultipleValidatorInterfaces_WiresValidationForEveryRequestType()
+    {
+        // One validator class may validate several request types (IValidator<A> +
+        // IValidator<B>). Discovery used to stop at the first matching interface, so B's
+        // requests reached their handler unvalidated — silently, with no diagnostic.
+        const string source = """
+            using FluentValidation;
+            using FluentValidation.Results;
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public record CreateOrder(string Name) : IRequest<int>;
+            public record UpdateOrder(string Name) : IRequest<int>;
+
+            public sealed class CreateOrderHandler : IRequestHandler<CreateOrder, int>
+            {
+                public ValueTask<int> HandleAsync(CreateOrder request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(1);
+            }
+
+            public sealed class UpdateOrderHandler : IRequestHandler<UpdateOrder, int>
+            {
+                public ValueTask<int> HandleAsync(UpdateOrder request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(2);
+            }
+
+            public sealed class SharedRulesValidator : AbstractValidator<CreateOrder>, IValidator<UpdateOrder>
+            {
+                public ValidationResult Validate(UpdateOrder instance) => new();
+
+                public Task<ValidationResult> ValidateAsync(UpdateOrder instance, CancellationToken cancellation = default)
+                    => Task.FromResult(new ValidationResult());
+            }
+            """;
+
+        var compilation = CreateCompilation(
+            [source],
+            [
+                MetadataReference.CreateFromFile(typeof(global::FluentValidation.IValidator).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(global::MediatorLite.FluentValidation.FluentValidationBehavior<,>).Assembly.Location),
+            ]);
+
+        var driver = CSharpGeneratorDriver.Create(new HandlerDiscoveryGenerator());
+        var ranDriver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out _);
+        var runResult = ranDriver.GetRunResult();
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+
+        generated.Should().Contain("global::FluentValidation.IValidator<global::DriverTests.CreateOrder>, global::DriverTests.SharedRulesValidator")
+            .And.Contain("global::FluentValidation.IValidator<global::DriverTests.UpdateOrder>, global::DriverTests.SharedRulesValidator",
+                "the validator must be registered for every IValidator<T> it implements");
+        generated.Should().Contain("FluentValidationBehavior<global::DriverTests.CreateOrder, int>")
+            .And.Contain("FluentValidationBehavior<global::DriverTests.UpdateOrder, int>",
+                "both handled request types have a validator, so both pipelines must validate");
+        generated.Should().Contain("public static int ValidatorCount => 2;");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
     public void UnrelatedEdit_LeavesGeneratorOutputsCached()
     {
         // The pipeline models must have value equality end-to-end: an edit that does not

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -165,6 +165,147 @@ public class SourceGeneratorDriverTests
     }
 
     [Fact]
+    public void GenericHandlerClass_WithClosedInterface_ReportsMedl1004_AndIsNotEmitted()
+    {
+        // The class is generic but the IRequestHandler<,> interface is fully closed. The
+        // class's fully-qualified display name (`UnusedParamHandler<TUnused>`) would be pasted
+        // verbatim into the generated registration, where TUnused is an unknown identifier
+        // (CS0246) — the consumer's build breaks inside a .g.cs file.
+        const string handlerSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public sealed class UnusedParamHandler<TUnused> : IRequestHandler<PingQuery, int>
+            {
+                public ValueTask<int> HandleAsync(PingQuery request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(request.Value);
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, handlerSource);
+
+        runResult.Diagnostics.Should().ContainSingle(d => d.Id == "MEDL1004")
+            .Which.GetMessage().Should().Contain("UnusedParamHandler");
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("UnusedParamHandler",
+            "a generic handler class must be skipped, not emitted as non-compiling code");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
+    public void OpenGenericHandlers_ReportMedl1004_AndAreNotEmitted()
+    {
+        // Open generic handlers (the MediatR pattern) cannot be closed by this generator:
+        // the interface type arguments are the class's own type parameters, so emission
+        // would produce `case TReq r_TReq:` and registrations full of unbound identifiers.
+        const string handlerSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public sealed class OpenRequestHandler<TReq, TRes> : IRequestHandler<TReq, TRes>
+                where TReq : IRequest<TRes>
+            {
+                public ValueTask<TRes> HandleAsync(TReq request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(default(TRes)!);
+            }
+
+            public sealed class OpenNotificationHandler<TNotification> : INotificationHandler<TNotification>
+                where TNotification : INotification
+            {
+                public ValueTask HandleAsync(TNotification notification, CancellationToken cancellationToken = default)
+                    => ValueTask.CompletedTask;
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, handlerSource);
+
+        var medl1004 = runResult.Diagnostics.Where(d => d.Id == "MEDL1004").ToList();
+        medl1004.Should().HaveCount(2);
+        medl1004.Select(d => d.GetMessage()).Should()
+            .Contain(m => m.Contains("OpenRequestHandler"))
+            .And.Contain(m => m.Contains("OpenNotificationHandler"));
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("OpenRequestHandler").And.NotContain("OpenNotificationHandler",
+            "open generic handlers must be skipped, not emitted as non-compiling code");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
+    public void HandlerNestedInGenericOuterType_ReportsMedl1004_AndIsNotEmitted()
+    {
+        // The handler itself is non-generic, but its containing type is generic, so its
+        // fully-qualified display name (`Outer<T>.InnerHandler`) still contains an unbound
+        // type parameter when emitted.
+        const string handlerSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public static class Outer<T>
+            {
+                public sealed class InnerHandler : IRequestHandler<PingQuery, int>
+                {
+                    public ValueTask<int> HandleAsync(PingQuery request, CancellationToken cancellationToken = default)
+                        => ValueTask.FromResult(request.Value);
+                }
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, handlerSource);
+
+        runResult.Diagnostics.Should().ContainSingle(d => d.Id == "MEDL1004")
+            .Which.GetMessage().Should().Contain("InnerHandler");
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("InnerHandler",
+            "a handler nested inside a generic type must be skipped, not emitted as non-compiling code");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
+    public void BehaviorNestedInGenericOuterType_ReportsMedl1002_AndIsNotEmitted()
+    {
+        // Same nesting hole for behaviors: the class's own type-parameter list is empty, so
+        // the pre-existing closed-interface check missed it, but the display name
+        // (`Outer<T>.InnerBehavior`) still carries the outer type's parameter.
+        const string behaviorSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public static class BehaviorOuter<T>
+            {
+                public sealed class InnerBehavior : IPipelineBehavior<PingQuery, int>
+                {
+                    public ValueTask<int> HandleAsync(
+                        PingQuery request,
+                        RequestHandlerDelegate<int> next,
+                        CancellationToken cancellationToken = default)
+                        => next();
+                }
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, behaviorSource);
+
+        runResult.Diagnostics.Should().ContainSingle(d => d.Id == "MEDL1002")
+            .Which.GetMessage().Should().Contain("InnerBehavior");
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("InnerBehavior",
+            "a behavior nested inside a generic type must be skipped, not emitted as non-compiling code");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
     public void NotificationStrategyAttributes_OnTypeFromReferencedAssembly_AreHonored()
     {
         // Standard consumer layout: notification contracts live in a referenced assembly,


### PR DESCRIPTION
## Summary

An adversarial bug hunt across the whole codebase — three parallel reviewers (source generator / runtime libraries / tests+benchmarks+CI+hooks) plus an independent full read of `HandlerDiscoveryGenerator.cs` and the runtime sources. The runtime libraries, tests, benchmarks, and CI came out **clean**; the real bugs were all in the source generator's discovery/emission edge cases, plus one hook script.

Every fix is TDD: the pinning test was written first and confirmed to fail for the documented reason before the fix. Branch ends at **125/125 tests passing** and a **warning-clean Release build** (this repo treats warnings as errors). One commit per fix.

## Fixes (severity order)

| # | Severity | Defect | How you'd hit it |
|---|----------|--------|------------------|
| **B1** | Medium | Generic/nested-generic handlers emitted unbound type parameters → **consumer build breaks** (CS0246) inside a `.g.cs` file, no diagnostic | Any generic handler class, an open generic handler (the MediatR pattern), or a handler nested in a generic type |
| **B2** | Medium | Covariant multi-response dispatch returned the **wrong handler's result** (boxed value counted as variance-assignable) | `IRequest<object> r = new MultiResponseQuery(5)` returned boxed `50` instead of `"value:5"` |
| **B3** | Low/Med | `Parallel` notifications ran every handler under an **already-cancelled** publish token; the other three strategies refuse | `cts.Cancel(); await mediator.PublishAsync(evt, cts.Token)` with ct-agnostic handlers |
| **B4** | Low/Med | A validator implementing `IValidator<T>` for several request types **silently validated only the first** | `class Shared : AbstractValidator<CreateOrder>, IValidator<UpdateOrder>` left `UpdateOrder` unvalidated |
| **B6** | Low | Closed behaviors for request types with no handler were registered in DI and counted in `BehaviorCount` (dead wiring) | Orphan `IPipelineBehavior<RetiredCommand, T>` after its handler was removed |
| **B7** | Low (breaking) | Generator honored the obsolete `[MediatorGeneration(Skip = true)]` while docs said discovery is unconditional | Contradiction either side could burn on |
| **B5** | Low | `00-save-context.csx` spliced the session id (external env var) into SQL literals + the snapshot filename | A quoted `MEDIATORLITE_SESSION_ID` broke every snapshot query, swallowed as a warning |

## Decisions baked in (confirmed with the maintainer)

- **B6** — filter dead behaviors (matches the existing validator policy); pinned counts unaffected.
- **B7** — make the code match the docs: the three `Skip` checks are removed and the attribute is now **inert**. The attribute *type* stays in Abstractions with its `[Obsolete]` marking (public-API contract). This is a **breaking** attribute-semantics change (rule 90 §3): shipped with an ADR (`.github/Memories/mediatorgeneration-skip-attribute-inert.md`), a migration-guide entry, and corrected README/quick-start/migration-from-mediatr docs that still advertised `Skip` as working. Exclusion is now structural — put the type in an assembly the generator doesn't run on.

## Not in scope

Four informational nits (immutability hardening on `ValidationException.Errors`, `Microsoft.Extensions.*` 9.0.0 on net10.0, a doc phrasing, two comment typos) were left untouched per the agreed scope.

## New diagnostic

`MEDL1004` (warning) — a handler class that is generic or nested inside a generic type is skipped instead of emitting non-compiling code. Registered in `AnalyzerReleases.Unshipped.md`.

## Learning artifacts

- Lesson: `.github/Lessons/2026-07-12-generator-discovery-guards-must-be-shared.md`
- Memory/ADR: `.github/Memories/mediatorgeneration-skip-attribute-inert.md`

## Verification

- `dotnet build MediatorLite.sln -c Release` → 0 warnings / 0 errors
- `dotnet test MediatorLite.sln` → 125/125 passing (was 116 at baseline; +9 new pinning tests)
- Each generator fix has a driver/dispatch test confirmed failing before and passing after
- Incrementality test (`UnrelatedEdit_LeavesGeneratorOutputsCached`) still passes after the B4 validator-model change
- B5 hook exercised end-to-end: valid id writes a real snapshot; `x' OR '1'='1` is refused with no file written

> Note: this environment can't execute the repo's `.claude` commit/push gates (`dotnet-script` can't run here, so the shim fails open by design). The build + test gates were run manually before every commit and the push, so their intent was honored — but on machines like this those gates are silently inactive, worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016jUjFYkZ9pmYQdZgU8whDD)_