### PR TITLE
fix(generator): support class-constrained open behaviors + generator hardening

### DIFF
--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -54,9 +54,9 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         messageFormat: "Pipeline behavior '{0}' has type parameters that cannot be bound from its "
             + "IPipelineBehavior<,> interface. Generic behavior classes are only supported in the canonical "
             + "shape Behavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> "
-            + "with no constraints beyond 'where TRequest : IRequest<TResponse>'. The behavior was not "
-            + "registered. Close the behavior over concrete types (as a non-generic class) or use the "
-            + "canonical open shape.",
+            + "with no constraints beyond 'where TRequest : IRequest<TResponse>' (optionally combined with "
+            + "'where TRequest : class'). The behavior was not registered. Close the behavior over concrete "
+            + "types (as a non-generic class) or use the canonical open shape.",
         category: "MediatorLite.Behaviors",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
@@ -363,13 +363,24 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             behaviorOrder = (int)(orderAttr.ConstructorArguments[0].Value ?? 0);
         }
 
+        // An open behavior carrying `where TRequest : class` must not be expanded over value-type
+        // requests — ExpandBehaviors filters those out to avoid emitting a CS0452-violating closed
+        // type. Any *supported* open IPipelineBehavior<,> interface guarantees TypeParameters[0] is
+        // the request param (IsSupportedOpenShape rejects declaration/interface order mismatches),
+        // so reading the reference-type constraint off it is correct; if no open interface survives
+        // discovery there is no open expansion and the flag is simply unused.
+        bool requestMustBeReferenceType = isOpenGeneric
+            && classSymbol.TypeParameters.Length == 2
+            && classSymbol.TypeParameters[0].HasReferenceTypeConstraint;
+
         return new BehaviorInfo(
             ClassName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             Namespace: classSymbol.ContainingNamespace?.ToDisplayString() ?? "",
             BehaviorInterfaces: new EquatableArray<BehaviorInterfaceInfo>(behaviorInterfaces.ToArray()),
             IsOpenGeneric: isOpenGeneric,
             Order: behaviorOrder,
-            HasUnsupportedOpenShape: hasUnsupportedOpenShape);
+            HasUnsupportedOpenShape: hasUnsupportedOpenShape,
+            RequestMustBeReferenceType: requestMustBeReferenceType);
     }
 
     /// <summary>
@@ -398,7 +409,12 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             return false;
         }
 
-        if (HasSpecialConstraints(requestParam) || HasSpecialConstraints(responseParam)
+        // The request param may carry `class` (HasReferenceTypeConstraint): it is satisfiable by
+        // every reference-type request, and expansion (ExpandBehaviors) skips any value-type
+        // request for such a behavior so no CS0452 is ever emitted. All other special
+        // constraints on the request param, and any special constraint on the response param,
+        // still make the shape unexpandable.
+        if (HasDisallowedRequestConstraints(requestParam) || HasSpecialConstraints(responseParam)
             || responseParam.ConstraintTypes.Length > 0)
         {
             return false;
@@ -419,6 +435,14 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         static bool HasSpecialConstraints(ITypeParameterSymbol parameter)
             => parameter.HasReferenceTypeConstraint
                || parameter.HasValueTypeConstraint
+               || parameter.HasNotNullConstraint
+               || parameter.HasUnmanagedTypeConstraint
+               || parameter.HasConstructorConstraint;
+
+        // Same as HasSpecialConstraints but tolerates the `class` constraint, which is safe to
+        // expand over reference-type requests (value-type requests are filtered at expansion).
+        static bool HasDisallowedRequestConstraints(ITypeParameterSymbol parameter)
+            => parameter.HasValueTypeConstraint
                || parameter.HasNotNullConstraint
                || parameter.HasUnmanagedTypeConstraint
                || parameter.HasConstructorConstraint;
@@ -601,7 +625,9 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                         InterfaceType: iface.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                         RequestType: typeArgs[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                         ResponseType: typeArgs[1].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                        BaseTypes: GetBaseTypeNames(typeArgs[0])));
+                        BaseTypes: GetBaseTypeNames(typeArgs[0]),
+                        RequestIsValueType: typeArgs[0].IsValueType,
+                        ResponseBaseTypes: GetBaseTypeNames(typeArgs[1])));
                 }
             }
             else if (originalDef == "MediatorLite.INotificationHandler<TNotification>")
@@ -800,6 +826,14 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             .ToList();
         var handledPairs = new HashSet<(string, string)>(requestResponsePairs);
 
+        // Request types that are value types cannot be substituted into an open behavior
+        // constrained `where TRequest : class` (CS0452), so such pairings are skipped below.
+        var valueTypeRequests = new HashSet<string>(
+            handlers
+                .SelectMany(h => h.RequestHandlers)
+                .Where(r => r.RequestIsValueType)
+                .Select(r => r.RequestType));
+
         foreach (var behavior in behaviors)
         {
             foreach (var behaviorInterface in behavior.BehaviorInterfaces)
@@ -808,6 +842,9 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 {
                     foreach (var (requestType, responseType) in requestResponsePairs)
                     {
+                        if (behavior.RequestMustBeReferenceType && valueTypeRequests.Contains(requestType))
+                            continue;
+
                         var baseTypeName = behavior.ClassName;
                         var genericMarkerIndex = baseTypeName.IndexOf('<');
                         if (genericMarkerIndex > 0)
@@ -1071,7 +1108,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         if (expandedBehaviors.Count > 0)
         {
             var nonValidationBehaviors = expandedBehaviors
-                .Where(b => !b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<"))
+                .Where(b => !b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<", StringComparison.Ordinal))
                 .ToList();
 
             if (nonValidationBehaviors.Count > 0)
@@ -1091,7 +1128,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         // --- Diagnostic counts ---
         var totalValidatorCount = validatorRegistrations.Count;
         var nonValidationBehaviorCount = expandedBehaviors
-            .Count(b => !b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<"));
+            .Count(b => !b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<", StringComparison.Ordinal));
 
         sb.AppendLine($"        /// <summary>Number of request handlers discovered at compile time.</summary>");
         sb.AppendLine($"        public static int RequestHandlerCount => {requestHandlers.Count};");
@@ -1139,7 +1176,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
             .ToDictionary(
                 g => g.Key,
                 g => g
-                    .OrderBy(b => b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<") ? 0 : 1)
+                    .OrderBy(b => b.BehaviorTypeName.StartsWith("global::MediatorLite.FluentValidation.FluentValidationBehavior<", StringComparison.Ordinal) ? 0 : 1)
                     .ThenBy(b => b.Order)
                     .ToList());
 
@@ -1293,7 +1330,21 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 sb.AppendLine("                    // so an IRequest<TResponse> reference can never originate from a");
                 sb.AppendLine("                    // value-type response interface — but IsAssignableTo alone would match");
                 sb.AppendLine("                    // one via boxing and silently run the wrong pipeline.");
-                foreach (var (_, iface) in group.Entries)
+                sb.AppendLine("                    // Candidates are emitted most-derived-first so a more specific response");
+                sb.AppendLine("                    // pipeline is preferred over a base one when both are assignable.");
+                // Order the covariant candidates most-derived-first: a candidate's depth is the
+                // number of its response base types that are themselves candidate response types
+                // (mirrors SortMostDerivedFirst). Ties keep discovery order (deterministic).
+                var covariantResponseNames = new HashSet<string>(
+                    group.Entries.Select(e => e.Interface.ResponseType!));
+                var covariantEntries = group.Entries
+                    .Select((e, idx) => (Entry: e, Index: idx,
+                        Depth: e.Interface.ResponseBaseTypes.Count(covariantResponseNames.Contains)))
+                    .OrderByDescending(x => x.Depth)
+                    .ThenBy(x => x.Index)
+                    .Select(x => x.Entry)
+                    .ToList();
+                foreach (var (_, iface) in covariantEntries)
                 {
                     var sendName = $"Send_{sendMethodSuffixes[(group.RequestType, iface.ResponseType!)]}";
                     sb.AppendLine($"                    if (!typeof({iface.ResponseType}).IsValueType && typeof({iface.ResponseType}).IsAssignableTo(typeof(TResponse)))");
@@ -1905,7 +1956,9 @@ internal sealed record HandlerInterfaceInfo(
     string InterfaceType,
     string RequestType,
     string? ResponseType,
-    EquatableArray<string> BaseTypes = default);
+    EquatableArray<string> BaseTypes = default,
+    bool RequestIsValueType = false,
+    EquatableArray<string> ResponseBaseTypes = default);
 
 internal sealed record NotificationHandlerInterfaceInfo(
     string InterfaceType,
@@ -1932,7 +1985,8 @@ internal sealed record BehaviorInfo(
     EquatableArray<BehaviorInterfaceInfo> BehaviorInterfaces,
     bool IsOpenGeneric,
     int Order = 0,
-    bool HasUnsupportedOpenShape = false);
+    bool HasUnsupportedOpenShape = false,
+    bool RequestMustBeReferenceType = false);
 
 internal sealed record BehaviorInterfaceInfo(
     string InterfaceType,

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -827,6 +827,131 @@ public class SourceGeneratorDriverTests
             "an edit that changes no discovered model must not regenerate sources");
     }
 
+    [Fact]
+    public void ClassConstrainedOpenBehavior_OverReferenceRequest_IsRegistered_AndReportsNoMedl1002()
+    {
+        // `where TRequest : class, IRequest<TResponse>` is a common MediatR-style shape. It is
+        // satisfiable by every reference-type request, so it must expand (not be rejected via
+        // MEDL1002). PingQuery from HandlerSource is a record => reference type.
+        const string behaviorSource = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public sealed class RefLoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+                where TRequest : class, IRequest<TResponse>
+            {
+                public ValueTask<TResponse> HandleAsync(
+                    TRequest request,
+                    RequestHandlerDelegate<TResponse> next,
+                    CancellationToken cancellationToken = default)
+                    => next();
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, behaviorSource);
+
+        runResult.Diagnostics.Should().NotContain(d => d.Id == "MEDL1002",
+            "a `where TRequest : class` open behavior is expandable and must not be rejected");
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().Contain("RefLoggingBehavior<global::DriverTests.PingQuery, int>",
+            "the class-constrained behavior must expand over the reference-type request");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
+    public void ClassConstrainedOpenBehavior_SkipsValueTypeRequests_AndStillCompiles()
+    {
+        // The same behavior must NOT be expanded over a value-type request: substituting a
+        // struct into `where TRequest : class` would emit a CS0452-violating closed type.
+        // Expansion filters value-type requests so the behavior applies only to reference
+        // requests, and AssertGeneratedOutputCompiles is the hard guard against CS0452.
+        const string source = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public readonly record struct StructQuery(int Value) : IRequest<int>;
+
+            public sealed class StructQueryHandler : IRequestHandler<StructQuery, int>
+            {
+                public ValueTask<int> HandleAsync(StructQuery request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(request.Value);
+            }
+
+            public sealed class RefOnlyBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+                where TRequest : class, IRequest<TResponse>
+            {
+                public ValueTask<TResponse> HandleAsync(
+                    TRequest request,
+                    RequestHandlerDelegate<TResponse> next,
+                    CancellationToken cancellationToken = default)
+                    => next();
+            }
+            """;
+
+        // HandlerSource contributes the reference-type PingQuery; `source` adds the struct request.
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(HandlerSource, source);
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().Contain("RefOnlyBehavior<global::DriverTests.PingQuery, int>",
+            "the class-constrained behavior must expand over the reference-type request");
+        generated.Should().NotContain("RefOnlyBehavior<global::DriverTests.StructQuery, int>",
+            "a `where TRequest : class` behavior must not be expanded over a value-type request");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
+    public void CovariantMultiResponseFallback_EmitsMostDerivedResponseFirst()
+    {
+        // A single request implementing IRequest<Dog> and IRequest<Puppy> (Puppy : Dog : Animal),
+        // dispatched via a common base with no exact handler, falls through to the covariant
+        // IsAssignableTo chain. That chain must test the most-derived response (Puppy) before its
+        // base (Dog), so the more specific pipeline is preferred over the base one.
+        const string source = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public class Animal { }
+            public class Dog : Animal { }
+            public class Puppy : Dog { }
+
+            public record BeastQuery(int Id) : IRequest<Dog>, IRequest<Puppy>;
+
+            public sealed class BeastDogHandler : IRequestHandler<BeastQuery, Dog>
+            {
+                public ValueTask<Dog> HandleAsync(BeastQuery request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(new Dog());
+            }
+
+            public sealed class BeastPuppyHandler : IRequestHandler<BeastQuery, Puppy>
+            {
+                public ValueTask<Puppy> HandleAsync(BeastQuery request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(new Puppy());
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(source);
+
+        var mediator = runResult.GeneratedTrees
+            .Select(t => t.ToString())
+            .Single(t => t.Contains("class SourceGeneratedMediator"));
+
+        var puppyAssignable = mediator.IndexOf(
+            "typeof(global::DriverTests.Puppy).IsAssignableTo(typeof(TResponse))", StringComparison.Ordinal);
+        var dogAssignable = mediator.IndexOf(
+            "typeof(global::DriverTests.Dog).IsAssignableTo(typeof(TResponse))", StringComparison.Ordinal);
+        puppyAssignable.Should().BeGreaterThan(-1);
+        dogAssignable.Should().BeGreaterThan(-1);
+        puppyAssignable.Should().BeLessThan(dogAssignable,
+            "the covariant fallback must emit the most-derived response candidate first");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
     private static (GeneratorDriverRunResult RunResult, Compilation Compilation) RunGenerator(params string[] sources)
     {
         var compilation = CreateCompilation(sources);


### PR DESCRIPTION
## Summary

Bug-hunt hardening pass over the source generator. Three parallel adversarial reviewers swept source-gen, runtime dispatch, and validation/abstractions; the codebase came back **clean** (no Critical/High/Medium bugs). Only three **LOW** findings survived verification — all fixed here. No public-abstractions surface changes (rule 90 → no ADR/migration needed).

## Findings fixed

| ID | Scenario | Fix |
|----|----------|-----|
| **F3** | An open behavior declared `where TRequest : class, IRequest<TResponse>` (a common MediatR-style shape) was rejected via **MEDL1002** and silently never registered. | Relax `IsSupportedOpenShape` to permit the reference-type constraint on the request param; filter value-type requests at **expansion** time so a `record struct` request never produces a CS0452-violating closed type. MEDL1002 message updated. |
| **F2** | The covariant multi-response fallback picked the assignable pipeline in **discovery order**, not most-derived-first. | Sort covariant candidates most-derived-first by response-type depth (mirrors `SortMostDerivedFirst`). Ties keep deterministic source order. |
| **F1** | Culture-sensitive `StartsWith` classified validation vs ordinary behaviors — feeding the public `BehaviorCount` constant and the validation-outermost ordering. | Pin to `StringComparison.Ordinal` (byte-identical output; removes a latent culture dependency). |

## Implementation notes

- Two model fields added for the mechanism: `RequestIsValueType` + `ResponseBaseTypes` on the handler-interface model, `RequestMustBeReferenceType` on the behavior model. All are deterministic functions of the symbols, so incremental-generator caching is preserved.
- The value-type skip lives in `ExpandBehaviors` because `IsSupportedOpenShape` runs per-class during discovery and can't see the full request-type set.

## Tests

Three isolated `SourceGeneratorDriverTests` (not shared `TestTypes.cs`, which would perturb dozens of `*Count` assertions):
- class-constrained behavior **is** registered over a reference request (no MEDL1002),
- the same behavior **skips** a `record struct` request and the generated output **still compiles** (guarded by `AssertGeneratedOutputCompiles` → catches any CS0452),
- covariant fallback emits the most-derived response candidate first.

## Verification

- `dotnet build MediatorLite.sln -c Release` — clean (0 warnings under warnings-as-errors).
- `dotnet test MediatorLite.sln` — **128/128 pass** (125 existing + 3 new).
- Sample source-gen stats unchanged (5 handlers / 3 notifications / 7 behaviors / 1 validator) — F1 is behavior-neutral and the sample has no class-constrained behavior.

## Residual note

A class-constrained open behavior where **every** discovered request is a value type now registers nothing silently (no MEDL1002). It genuinely cannot apply to any request, so this is harmless; a diagnostic for that dead-behavior case could be added if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)