### PR TITLE
Fix Blazor/Mono WebAssembly crash: make Unit.CompletedTask a computed property

### DIFF
--- a/src/MediatorLite.Abstractions/Abstractions/Unit.cs
+++ b/src/MediatorLite.Abstractions/Abstractions/Unit.cs
@@ -17,7 +17,16 @@ public readonly record struct Unit : IEquatable<Unit>, IComparable<Unit>
     /// <summary>
     /// Returns a completed <see cref="ValueTask{Unit}"/> with the default <see cref="Unit"/> value.
     /// </summary>
-    public static ValueTask<Unit> CompletedTask { get; } = ValueTask.FromResult(Value);
+    /// <remarks>
+    /// Implemented as a computed (expression-bodied) property rather than a get-only auto-property so
+    /// that <see cref="Unit"/> does not declare a <c>static</c> field of type <see cref="ValueTask{Unit}"/>.
+    /// Such a self-referential static field (<c>Unit</c> statically holding a <c>ValueTask&lt;Unit&gt;</c>)
+    /// trips the Mono/WASM type loader's recursion detector while loading <c>ValueTask&lt;Unit&gt;</c>,
+    /// aborting the runtime (native <c>object.c</c> assertion / <c>TypeLoadException: Recursive type
+    /// definition detected</c>) on Blazor WebAssembly. A completed <see cref="ValueTask{Unit}"/> is a
+    /// cheap, allocation-free struct, so computing it on each access has no meaningful cost.
+    /// </remarks>
+    public static ValueTask<Unit> CompletedTask => ValueTask.FromResult(Value);
 
     /// <summary>
     /// Compares this instance with another <see cref="Unit"/> instance.

--- a/tests/MediatorLite.Tests/UnitTests/UnitTypeTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/UnitTypeTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace MediatorLite.Tests.UnitTests;
+
+/// <summary>
+/// Tests for the <see cref="Unit"/> value type, including a structural regression guard against the
+/// Blazor/Mono WebAssembly type-loader crash described below.
+/// </summary>
+public class UnitTypeTests
+{
+    /// <summary>
+    /// Regression guard for the Blazor WASM (Mono) crash.
+    /// <para>
+    /// <see cref="Unit"/> must never declare a <c>static</c> field whose type is
+    /// <see cref="ValueTask{Unit}"/>. Such a self-referential static field
+    /// (<c>Unit</c> statically holding a <c>ValueTask&lt;Unit&gt;</c>) makes the Mono/WASM type loader's
+    /// recursion detector abort while loading <c>ValueTask&lt;Unit&gt;</c> — a native
+    /// <c>object.c</c> assertion / <c>TypeLoadException: Recursive type definition detected</c> — the
+    /// first time the recursive load path is hit (e.g. the generated mediator's
+    /// <c>SendAsync&lt;Unit&gt;</c> dispatch). The failure is load-order dependent and does not occur on
+    /// CoreCLR, which is why it can slip through non-WASM tests.
+    /// </para>
+    /// <para>
+    /// This is why <see cref="Unit.CompletedTask"/> is an expression-bodied (computed) property rather
+    /// than a get-only auto-property: an auto-property would emit exactly such a static backing field.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Unit_HasNoStaticFieldOfTypeValueTaskOfUnit()
+    {
+        var offendingFields = typeof(Unit)
+            .GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(f => f.FieldType == typeof(ValueTask<Unit>))
+            .Select(f => f.Name)
+            .ToArray();
+
+        offendingFields.Should().BeEmpty(
+            "a static ValueTask<Unit> field on Unit makes ValueTask<Unit> self-referential and aborts "
+            + "the Mono/WASM type loader; keep Unit.CompletedTask a computed property. Offending: {0}",
+            string.Join(", ", offendingFields));
+    }
+
+    /// <summary>
+    /// Confirms <see cref="Unit.CompletedTask"/> is a completed task that yields <see cref="Unit.Value"/>.
+    /// </summary>
+    [Fact]
+    public async Task CompletedTask_IsCompleted_AndReturnsValue()
+    {
+        var task = Unit.CompletedTask;
+
+        task.IsCompletedSuccessfully.Should().BeTrue("Unit.CompletedTask must be an already-completed task");
+        (await task).Should().Be(Unit.Value, "the completed task must yield the singleton Unit value");
+    }
+}


### PR DESCRIPTION
## Fix Blazor/Mono WebAssembly crash: make `Unit.CompletedTask` a computed property

### TL;DR

On Blazor WebAssembly (Mono), any app that dispatches a request through the v2 source-generated mediator aborts the runtime the first time `ValueTask<Unit>` is loaded. The root cause is a single self-referential `static` field on `Unit`. This PR changes `Unit.CompletedTask` from a get-only auto-property to an expression-bodied (computed) property — a one-line change, no public API break, no allocation cost — and adds a regression guard.

### Symptom

A Blazor WASM client that calls `IMediator.SendAsync(...)` / `PublishAsync(...)` freezes at the first dispatch, and the browser console shows one of two manifestations of the same failure:

- Debug / interpreter:
  ```
  [MONO] * Assertion at /__w/1/s/src/runtime/src/mono/mono/metadata/object.c:8000, condition `<disabled>' not met
  ```
- Release / published, in some builds:
  ```
  System.TypeLoadException: Recursive type definition detected System.Threading.Tasks.ValueTask`1
  ```

Both are the Mono type loader failing to load `ValueTask<Unit>`. The native assertion is **not** catchable by `try/catch`. The same code runs fine on CoreCLR (server-side, console, tests), which is why the existing test suite does not catch it.

### Root cause

`MediatorLite.Abstractions.Unit` declares:

```csharp
public static ValueTask<Unit> CompletedTask { get; } = ValueTask.FromResult(Value);
```

A get-only **auto-property with an initializer** compiles to a `static` backing **field** — here `static ValueTask<Unit> <CompletedTask>k__BackingField` — declared **inside `Unit` itself**. That makes `Unit` statically self-referential:

```
Unit  ──(static field)──▶  ValueTask<Unit>  ──(struct field _result)──▶  Unit  ──▶ …
```

Mono's WebAssembly type loader has an over-aggressive recursion detector (same family as [dotnet/runtime#85821](https://github.com/dotnet/runtime/issues/85821)) that aborts while resolving `ValueTask<Unit>` when that recursive path is the **first** one taken to load the type.

Two properties make this easy to misdiagnose:

1. **Load-order dependent.** If `ValueTask<Unit>` is first brought in via a *benign* path (e.g. touching `Unit.CompletedTask` directly, or any other code that instantiates `ValueTask<Unit>` before the mediator does), the type is loaded successfully and the crash is *masked* for the rest of the process. The generated mediator's `SendAsync<Unit>` dispatch is typically the first place `ValueTask<Unit>` is instantiated in a real app, so that is where it blows up.
2. **v2-only.** v1's `IMediator` returned `Task<T>` (a reference type), so no self-referential *struct* field was ever created. v2 returns the `ValueTask<TResponse>` struct, which is what introduces the `Unit → ValueTask<Unit> → Unit` cycle through the static field.

### The fix

```csharp
public static ValueTask<Unit> CompletedTask => ValueTask.FromResult(Value);
```

An expression-bodied property has **no backing field**, so `Unit` no longer declares a `static ValueTask<Unit>` field and the static self-reference disappears. The type loader has nothing to recurse into, so the abort is gone — independent of load order.

- **No public API break.** `Unit.CompletedTask` remains a readable `static ValueTask<Unit>` property; existing callers (including handlers that `return Unit.CompletedTask;`) compile and behave identically.
- **No cost.** A completed `ValueTask<Unit>` is an allocation-free struct wrapping a synchronously-available result, so computing it per access is effectively free (no `Task` allocation, no heap traffic).

### Reproduction

A minimal, self-contained Blazor WASM app (net10.0, Mono interpreter, `PublishTrimmed=false`, `PublishAot=false`) with **no third-party dependency other than MediatorLite** reproduces it deterministically: register the generated mediator (`AddGeneratedHandlers().AddMediatorLite()`) and, as the app's first action, dispatch a `Unit`-returning command through `IMediator`. On the current release (2.0.5) the page aborts with the `object.c:8000` assertion; with this change every dispatch (`Unit`, value-type and reference-type responses) completes and the page renders. Verified on `Microsoft.NETCore.App.Runtime.Mono.browser-wasm` 10.0.8 and 10.0.9 (latest stable at the time of writing).

**Standalone reproduction repo:** https://github.com/SolemnDucc/blazor-wasm-mediatorlite-v2-repro — the page runs hand-written `ValueTask<T>` probes (all render `OK`, showing the trigger is not `ValueTask<T>` in general) followed by the generated-mediator dispatch that aborts the runtime; its README walks through the same root cause and fix.

### Testing

- **New regression guard** (`UnitTypeTests.Unit_HasNoStaticFieldOfTypeValueTaskOfUnit`): reflects over `Unit` and asserts it declares **no** `static` field of type `ValueTask<Unit>`. It fails on the old auto-property (detects `<CompletedTask>k__BackingField`) and passes with the fix, so the regression is locked out on ordinary (non-WASM) CI where the runtime abort itself cannot be observed.
- **Behavioral check** that `Unit.CompletedTask` is already completed and yields `Unit.Value`.
- **Full existing suite passes: 103/103** (was 101; +2 new).

### Notes

- The Mono assertion is arguably also a runtime bug (a type loader should never abort on valid managed IL that CoreCLR accepts); I'm happy to file a corresponding `dotnet/runtime` issue. Regardless, avoiding the self-referential static field is a cheap, self-contained fix on the MediatorLite side and makes v2 usable on Blazor WebAssembly today.
- There is no `CHANGELOG.md` in the repo to update.
