### PR TITLE
docs(release): v2.1.0 release notes + open-findings review

### DIFF
--- a/docs/releases/v2.1.0-open-findings.md
+++ b/docs/releases/v2.1.0-open-findings.md
@@ -1,0 +1,144 @@
+# Open findings — observed while preparing the v2.1.0 release notes
+
+**Status: for your review. No code was changed.**
+
+Three items surfaced while verifying PRs #22–#27 against the code on `de46f39`. None is a dispatch or correctness bug in the library — the runtime, generator emission, and validation surfaces all held up under this pass. Two are release-process gaps and one is a known, deliberately-accepted silent case.
+
+Each item below states what I observed, how I verified it, why it matters, and what I'd recommend. Severity is my assessment, not a shipped classification.
+
+| # | Item | Severity | Type |
+|---|---|---|---|
+| [1](#1-analyzer-release-tracking-is-not-being-maintained-across-releases) | Analyzer release tracking never advances to `Shipped.md` | Low | Release process |
+| [2](#2-microsoftextensions-900-referenced-from-a-net100-package) | `Microsoft.Extensions.*` 9.0.0 on a net10.0 package | Informational | Dependency hygiene |
+| [3](#3-a-class-constrained-open-behavior-can-register-nothing-silently) | Class-constrained open behavior can register nothing, silently | Low | Generator diagnostics gap |
+
+---
+
+## 1. Analyzer release tracking is not being maintained across releases
+
+**Severity:** Low · **Area:** `src/MediatorLite.SourceGeneration/AnalyzerReleases.*.md`
+
+### What I observed
+
+All four diagnostics — `MEDL1001`, `MEDL1002`, `MEDL1003`, `MEDL1004` — are listed in `AnalyzerReleases.Unshipped.md`. `AnalyzerReleases.Shipped.md` contains no rules at all, only the header comment.
+
+But `MEDL1001` and `MEDL1002` **have shipped**. They are in the package published from tag `v2.0.5`.
+
+### How I verified it
+
+```bash
+# MEDL1001 and MEDL1002 were already in Unshipped.md at the v2.0.5 tag:
+git show v2.0.5:src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md | grep MEDL
+# → MEDL1001 | MediatorLite.Validation | Error | ...
+# → MEDL1002 | MediatorLite.Behaviors | Warning | ...
+
+# Shipped.md had zero rules at that tag, and still does on main:
+git show v2.0.5:src/MediatorLite.SourceGeneration/AnalyzerReleases.Shipped.md | grep -c MEDL
+# → 0
+```
+
+Cross-check: `MEDL1002` was introduced by PR #22, and PR #22's merge commit `9fa7cdd` is contained in tag `v2.0.5` (`git tag --contains 9fa7cdd` → `v2.0.5`). So a rule that shipped in v2.0.5 is still filed as unshipped two releases later.
+
+### Why it matters
+
+The files are wired into the build as `AdditionalFiles` for the RS2008 release-tracking analyzer, and `EnforceExtendedAnalyzerRules` is on. The convention these files implement is: when a release is cut, rules move from `Unshipped.md` into a versioned section of `Shipped.md`. That record is what lets the analyzer detect a **later** breaking change to a rule — a severity downgrade, a category change, a removal — and warn about it. Because nothing has ever moved, that protection is inert: the tracking files are being maintained as a declaration list rather than as release history.
+
+This is not currently breaking the build. It is a checklist gap that quietly gets more expensive the longer it runs, since reconstructing which rule shipped in which version requires archaeology of exactly the kind I just did.
+
+### Recommendation
+
+Add a step to `/release-workflow`: before tagging, move the newly-shipped rules from `Unshipped.md` into a `## Release X.Y.Z` section in `Shipped.md`. For this release that means backfilling `MEDL1001` and `MEDL1002` under a `## Release 2.0.5` section and moving `MEDL1003` / `MEDL1004` under `## Release 2.1.0`.
+
+**Caveat I could not resolve:** I did not verify against the published NuGet package that v2.0.5's analyzer actually contains both rules — I inferred it from the tag containing the commit that declares them. The inference is sound but is not a package-level check.
+
+---
+
+## 2. `Microsoft.Extensions.*` 9.0.0 referenced from a net10.0 package
+
+**Severity:** Informational · **Area:** `src/MediatorLite/MediatorLite.csproj`
+
+### What I observed
+
+```xml
+<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+```
+
+while `Directory.Build.props` sets `<TargetFramework>net10.0</TargetFramework>`.
+
+PR #24 flagged this as an informational nit and left it untouched per the agreed scope of that PR. You asked me to re-raise it with analysis, so:
+
+### Analysis
+
+This is **not a bug** and I want to be clear about that before the reasoning. NuGet resolves this fine, the package restores, and the build is clean. A 9.0.0 abstractions package is consumable from a net10.0 project, and both of these are abstractions packages — they are among the most stable, least-churning assemblies Microsoft ships.
+
+The actual consideration is a floor-versus-ceiling one. A `PackageReference` states a **minimum**. A consumer app on net10.0 will almost certainly already be pulling `Microsoft.Extensions.*` 10.x transitively through the shared framework or through ASP.NET Core, and NuGet's nearest-wins/highest-wins resolution will unify to the higher version. So in practice most consumers never see 9.0.0 at all. The reference is a floor that no realistic consumer sits on.
+
+Arguments for leaving it at 9.0.0:
+
+- A lower floor is a *feature* for a library: it maximises the range of consumers who can install without a forced upgrade of their own dependency graph.
+- These are abstractions. `IServiceCollection` and `ILogger<T>` have not changed in ways MediatorLite touches.
+- Bumping it is a NuGet-visible change to the dependency graph for zero functional gain.
+
+Arguments for bumping to 10.0.x:
+
+- Version coherence with the declared TFM: a net10.0-only package declaring 9.0.0 dependencies reads as an oversight to anyone auditing the `.nuspec`, and invites exactly the question I am writing up here.
+- It removes a downgrade-warning surface in consumer graphs that pin explicitly.
+
+### Recommendation
+
+**Leave it, and document the intent** — the low floor is defensible and probably deliberate. If you want the audit question to stop recurring, a one-line comment in `MediatorLite.csproj` saying *"9.0.0 is a deliberate minimum floor; consumers on net10 unify to 10.x"* costs nothing and settles it permanently.
+
+I am explicitly not recommending a bump. I'd want your call on whether the floor is intentional before anyone changes it — if it is intentional, changing it is a small regression in consumer reach.
+
+---
+
+## 3. A class-constrained open behavior can register nothing, silently
+
+**Severity:** Low · **Area:** `HandlerDiscoveryGenerator.ExpandBehaviors`
+
+### What I observed
+
+This is PR #25's own residual note, which its author recorded and judged harmless. I agree it is harmless in effect, and I'd still argue it deserves a diagnostic. Recording it here so the reasoning survives.
+
+PR #25 (F3) relaxed `IsSupportedOpenShape` to accept an open behavior declared `where TRequest : class, IRequest<TResponse>` — a common MediatR-style shape that was previously rejected via `MEDL1002` and silently never registered. Because a `class` constraint cannot be satisfied by a value-type request, value-type requests are filtered at **expansion** time (`HandlerDiscoveryGenerator.cs:845`), so no `CS0452`-violating closed type is ever emitted:
+
+```csharp
+if (behavior.RequestMustBeReferenceType && valueTypeRequests.Contains(requestType))
+```
+
+The consequence: if **every** discovered request in the compilation is a value type, that behavior expands to nothing. It registers nothing, applies to nothing, and reports nothing — no `MEDL1002`, because the shape is now supported, and no other diagnostic, because expansion-time filtering is not a diagnostic site.
+
+### Why it matters (and why it's genuinely low)
+
+The behavior *cannot* apply to any request in that compilation — the constraint makes it impossible — so the silence is not hiding incorrect dispatch. Nothing runs wrong. This is why the PR author called it harmless, and that call is correct.
+
+The gap is a developer-experience one, and it is the same shape as the class of defect this release spent six PRs closing: **the author of that behavior believes it is running.** They wrote a pipeline behavior, the build is clean, no warning appears, and the behavior never executes. That is precisely the failure mode `MEDL1003` and `MEDL1004` were added to eliminate. The repo's own stated policy — the lesson at `.github/Lessons/2026-07-12-generator-discovery-guards-must-be-shared.md` — is that a silently-skipped type should be a diagnostic.
+
+It is low severity because the trigger is narrow: it needs an all-value-type request set in one compilation, which is unusual, since `record` requests (the convention this repo documents) are reference types.
+
+### Recommendation
+
+Consider a new warning — `MEDL1005` — reported when a discovered open behavior expands to zero closed registrations. That message would cover this case and any future expansion-time filter that empties a behavior. It is additive, needs no API change, and follows the established `MEDL1002` / `MEDL1004` pattern of *diagnostic plus skip*.
+
+**Not urgent, and I would not hold the release for it.** Filing as a follow-up issue is the right weight.
+
+---
+
+## What I checked that came back clean
+
+Stated so the negative result is on record and does not get re-derived later:
+
+- `ValidationException` — both public constructors route through `Freeze(...)`, which null-guards and snapshots into an array. PR #22's claim is accurate; the `Errors` property is genuinely immutable.
+- `[MediatorGeneration(Skip = ...)]` inertness — verified no code under `src/` reads the attribute. The only hits are the declaration in `Attributes.cs:228` and a README line stating it has no effect. PR #24's B7 is complete, not partial.
+- `Unit.CompletedTask` — confirmed expression-bodied on `origin/main` (`Unit.cs:29`). PR #26's fix is present.
+- Diagnostics `MEDL1001`–`MEDL1004` — all four declared in the generator and registered in `AnalyzerReleases.Unshipped.md` (see finding 1 re: the file they're in).
+- `.gitattributes` — present with the pinning PR #27 describes.
+- Notification cancellation — the generated catch is `catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }`, matching the semantics rule 40 documents, with `ct.ThrowIfCancellationRequested()` guarding the parallel start phase.
+- Full suite — 131/131 passing, run on the release commit.
+
+## Method and limits
+
+Findings 1 and 3 are grounded in commands whose output I reproduced above. Finding 2 is an analysis of a fact (the version numbers) that is not in dispute.
+
+This was a verification pass over the six PRs' claims, **not** an independent adversarial audit of the codebase — the PRs themselves each ran one, and #24, #25, and #27 all report the library coming back clean. I did not re-run those audits. If you want a fresh bug hunt rather than a claims-verification pass, that is a separate job and I'd scope it separately.

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,238 @@
+# MediatorLite v2.1.0
+
+**Stability and correctness release.** Six merged pull requests (#22–#27), all bug fixes. No new features, no new public API.
+
+The headline for consumers: **MediatorLite v2 now runs on Blazor WebAssembly**, where every dispatch previously aborted the Mono runtime. Beyond that, this release closes a family of source-generator defects that broke consumer builds with compiler errors *inside generated files*, corrects notification cancellation semantics that were wrong in v2.0.5, and adds two new build-time diagnostics that turn silent misconfiguration into visible warnings.
+
+> **One breaking change** — `[MediatorGeneration(Skip = true)]` is now inert. See [Breaking change](#breaking-change) before upgrading.
+
+**Previous release:** v2.0.5 (2026-07-04) · **Packages:** `MediatorLite`, `MediatorLite.Abstractions`, `MediatorLite.SourceGeneration`, `MediatorLite.FluentValidation`
+
+---
+
+## At a glance
+
+| If you… | Read |
+|---|---|
+| Target **Blazor / Mono WebAssembly** | [Blazor WebAssembly crash fixed](#blazor-webassembly-crash-fixed) — this release unblocks you entirely |
+| Use `[MediatorGeneration(Skip = true)]` | [Breaking change](#breaking-change) — **action required** |
+| Rely on `ContinueAndAggregate` notifications | [Notification cancellation semantics](#notification-cancellation-semantics-corrected) — behavior differs from v2.0.5 |
+| Write **generic handlers** or **open behaviors** | [Generator: emission correctness](#generator-emission-correctness) and [New diagnostics](#new-diagnostics) |
+| Declare handlers as `record`, `partial`, or multi-response | [Generator: discovery coverage](#generator-discovery-coverage) |
+| Contribute to this repo | [Repository infrastructure](#repository-infrastructure-not-shipped-in-packages) |
+
+---
+
+## Breaking change
+
+### `[MediatorGeneration(Skip = true)]` no longer skips anything
+
+The generator used to honour `Skip = true` and exclude the type from discovery. The documentation stated the opposite — that v2 discovery is unconditional. Code and docs contradicted each other, and either side could burn you.
+
+**Resolution:** the code now matches the documentation. The three `Skip` checks were removed; the attribute is inert. The attribute *type* remains in `MediatorLite.Abstractions` with its `[Obsolete]` marking, because deleting a public type is itself a breaking change (repo rule 90 §4).
+
+**Who this affects:** any consumer relying on `Skip = true` to keep a handler out of the generated registration. That handler is now **discovered, registered, and dispatched**. If two handlers exist for one `(request, response)` pair and you were suppressing one with `Skip`, the suppressed handler now participates — and you will see the new `MEDL1003` warning naming the dead one.
+
+**Migration:** exclusion is now structural. Move the type into an assembly the generator does not run on.
+
+```csharp
+// Before — no longer has any effect:
+[MediatorGeneration(Skip = true)]
+public class ExperimentalHandler : IRequestHandler<FooQuery, FooResult> { }
+
+// After — move the type to a project that does not reference MediatorLite.SourceGeneration.
+```
+
+**Rationale for the minor version bump:** this changes the semantics of a public attribute, which repo rule 90 §3 classifies as breaking. It ships with an ADR (`.github/Memories/mediatorgeneration-skip-attribute-inert.md`), a migration-guide entry, and corrections to the README, quick-start, and migrate-from-MediatR docs that had advertised `Skip` as working.
+
+*From #24.*
+
+---
+
+## Blazor WebAssembly crash fixed
+
+**Symptom:** on Blazor WebAssembly (Mono), the first `IMediator.SendAsync(...)` / `PublishAsync(...)` aborted the runtime. The page froze, and the browser console showed either a native Mono assertion (`object.c:8000`, **not catchable** by `try`/`catch`) or `System.TypeLoadException: Recursive type definition detected System.Threading.Tasks.ValueTask'1`. Both are the Mono type loader failing to load `ValueTask<Unit>`.
+
+**Root cause:** `Unit.CompletedTask` was a get-only auto-property with an initializer, which the compiler lowers to a `static` backing field *inside `Unit` itself*:
+
+```
+Unit ──(static field)──▶ ValueTask<Unit> ──(struct field _result)──▶ Unit ──▶ …
+```
+
+Mono's WebAssembly type loader has an over-aggressive recursion detector (same family as [dotnet/runtime#85821](https://github.com/dotnet/runtime/issues/85821)) that aborts on this cycle when the recursive path is the *first* one taken to load the type.
+
+Two properties made it hard to diagnose. It is **load-order dependent** — if `ValueTask<Unit>` is first loaded via a benign path, the crash is masked for the rest of the process, and the generated mediator's dispatch is typically the first place a real app instantiates it. And it is **v2-only** — v1's `IMediator` returned `Task<T>`, a reference type, so no self-referential struct field ever existed. CoreCLR (server-side, console, tests) accepts the same IL happily, which is why CI never caught it.
+
+**Fix** — one line, no API break, no allocation cost:
+
+```csharp
+public static ValueTask<Unit> CompletedTask => ValueTask.FromResult(Value);
+```
+
+An expression-bodied property has no backing field, so the static self-reference disappears and the type loader has nothing to recurse into — independent of load order.
+
+**Regression guard:** `UnitTypeTests.Unit_HasNoStaticFieldOfTypeValueTaskOfUnit` reflects over `Unit` and asserts it declares no `static` field of type `ValueTask<Unit>`. It fails on the old auto-property and passes with the fix, locking the regression out on ordinary CI where the runtime abort cannot be observed.
+
+**Verified on** `Microsoft.NETCore.App.Runtime.Mono.browser-wasm` 10.0.8 and 10.0.9, against a [standalone reproduction repo](https://github.com/SolemnDucc/blazor-wasm-mediatorlite-v2-repro).
+
+*From #26, contributed by [@SolemnDucc](https://github.com/SolemnDucc).*
+
+---
+
+## Notification cancellation semantics corrected
+
+Two independent cancellation defects are fixed. **If you upgrade from v2.0.5, `ContinueAndAggregate` behaves differently — deliberately.**
+
+### A handler's own `OperationCanceledException` is an ordinary fault
+
+v2.0.5 special-cased any `OperationCanceledException` from a notification handler. Under `Parallel` + `ContinueAndAggregate`, the first one found was rethrown unwrapped and **every sibling fault was silently dropped**. Under `Sequential` / `StopOnFirst`, it stopped the remaining handlers from running — contradicting the documented contract.
+
+The distinction that was missing: *whose* cancellation is it? A handler's internal timeout or linked token is not the publish operation being cancelled.
+
+**Now:**
+
+- A handler's own `OperationCanceledException`, with the publish token **not** cancelled, is an ordinary fault. Under `ContinueAndAggregate` it aggregates with its siblings into one `AggregateException`; under `Sequential` / `StopOnFirst` the remaining handlers still run.
+- Only when the **publish** `CancellationToken` is genuinely cancelled does an unwrapped `OperationCanceledException` surface. The generated catch is explicit about it:
+
+  ```csharp
+  catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+  ```
+
+**Pinned by:** `PublishAsync_ParallelAggregate_HandlerInternalOce_AggregatesAllFaults`, `PublishAsync_ParallelAggregate_GenuineCancellation_SurfacesOceUnwrapped`, `PublishAsync_SequentialAggregate_HandlerInternalOce_DoesNotSkipRemainingHandlers`. Documented in rule 40 and the `ContinueAndAggregate` XML docs.
+
+*From #23 — correcting behavior introduced in #22 and shipped in v2.0.5.*
+
+### `Parallel` now honours an already-cancelled publish token
+
+`Parallel` ran every handler even when the publish token was cancelled before the call. The other three strategies refuse. Hit by `cts.Cancel(); await mediator.PublishAsync(evt, cts.Token);` with cancellation-agnostic handlers.
+
+The generated `Parallel` path now calls `ct.ThrowIfCancellationRequested()` before the start phase, matching the other strategies. Pinned by `PublishAsync_Parallel_WithPreCancelledToken_ThrowsOceWithoutRunningHandlers`.
+
+*From #24 (B3).*
+
+---
+
+## Generator: emission correctness
+
+This class of defect is the worst kind a source generator produces: **the consumer's build breaks with a compiler error inside a `.g.cs` file they did not write, with no diagnostic explaining why.** Every fix below either emits correct code or reports a proper diagnostic and skips.
+
+| Defect | How you would hit it | Fix |
+|---|---|---|
+| Generic and nested-generic **handlers** emitted unbound type parameters (`CS0246`) | Any generic handler class, an open generic handler (the MediatR pattern), or a handler nested in a generic outer type | New **`MEDL1004`** warning; the type is skipped instead of breaking the build (#24, B1) |
+| Generic **behaviors** whose `IPipelineBehavior<,>` interface is closed or *partially* closed emitted unbound type parameters, with no diagnostic | A type parameter nested inside an interface argument | `MEDL1002` now rejects them (#23) |
+| Behaviors nested inside generic outer types truncated the display name at the outer `<`, emitting **the wrong type name entirely** | Handler or behavior nested in a generic type | Containing-type-aware guard shared across handler, behavior, and validator discovery (#24, B1) |
+| Open behaviors constrained `where TRequest : class, IRequest<TResponse>` — a common MediatR shape — were rejected by `MEDL1002` and **silently never registered** | Any class-constrained open behavior | `IsSupportedOpenShape` permits the reference-type constraint; value-type requests are filtered at *expansion* time so no `CS0452`-violating closed type is emitted (#25, F3) |
+| Switch-arm ordering ignored implemented interfaces, producing order-dependent `CS8120` subsumption errors | A concrete implementor and an interface-typed message both having arms | Interfaces now count as supertypes, so a concrete arm always precedes an interface-typed arm (#23) |
+| `Send_*` / `Publish_*` suffixes collided (`CS0111` / `CS0121`) | A multi-response request whose response types sanitize to the same identifier | Suffixes are deterministically uniquified (#23) |
+| Covariant multi-response dispatch returned **the wrong handler's result** | `IRequest<object> r = new MultiResponseQuery(5)` returned boxed `50` instead of `"value:5"` — a boxed value counted as variance-assignable | Boxing excluded from the variance check (#24, B2) |
+| Covariant fallback picked the assignable pipeline in **discovery order**, not most-derived-first | Multi-response request with a response hierarchy | Candidates sorted most-derived-first by response-type depth; ties keep deterministic source order (#25, F2) |
+| Generic type names leaked mangled or `global::`-prefixed text into log and activity display names | Any generic or tuple type in a request/notification name | Name sanitization fixed; `StripGlobalPrefix` strips *every* occurrence (#22, #23) |
+| Culture-sensitive `StartsWith` classified validation vs ordinary behaviors — feeding the public `BehaviorCount` and the validation-outermost ordering | A culture where the ordinal assumption fails | Pinned to `StringComparison.Ordinal`; byte-identical output, latent culture dependency removed (#25, F1) |
+
+---
+
+## Generator: discovery coverage
+
+Types that *should* have been discovered but were silently skipped, and types that were discovered twice.
+
+- **`record`-declared handlers, behaviors, and validators are now discovered.** Discovery matched only `ClassDeclarationSyntax`, so records were silently skipped. `record struct` stays excluded — DI implementation types must be classes. (#22)
+- **`partial` types register once, not once per part.** Discovery deduplicates by fully-qualified name, so a partial type with base lists in several declarations no longer registers and dispatches multiple times. (#22)
+- **Multi-response requests dispatch correctly.** A request implementing `IRequest<T>` for several `T` now gets one fully-typed `Send_*` pipeline per `(request, response)` pair instead of throwing `InvalidCastException`. (#22)
+- **Attributes declared in a referenced assembly are honoured.** `[NotificationExecution]` / `[NotificationError]` are read from the notification type symbol during discovery, so strategies declared on types in a referenced contracts assembly no longer fall back silently to `Sequential` / `StopOnFirstError`. (#23)
+- **Attribute matching is namespace-qualified.** Matching is now on namespace + name, mirroring the interface checks. A same-named attribute from a foreign namespace can no longer silently disable logging or tracing, or change strategies, orders, or skip behavior. (#23)
+- **A validator covering several request types validates all of them.** `IValidator<T>` implemented for multiple request types previously validated only the first — e.g. `class Shared : AbstractValidator<CreateOrder>, IValidator<UpdateOrder>` left `UpdateOrder` unvalidated. (#24, B4)
+- **Dead closed behaviors are no longer registered.** A closed behavior for a request type with no handler was registered in DI and counted in `BehaviorCount`. It is now filtered, matching the existing validator policy. Pinned counts are unaffected. (#24, B6)
+- **Concrete notification handlers register once per class.** `AddGeneratedNotificationHandlers()` emitted `services.AddTransient<Concrete>()` once *per implemented interface*, so a handler implementing two `INotificationHandler<>` interfaces produced duplicate `ServiceDescriptor`s. Deduplicated by fully-qualified class name; interface registrations are still emitted per interface, and emission order is unchanged. (#27)
+- **Incremental caching restored.** Pipeline model records use `EquatableArray<T>` (value equality) instead of `List<>`, and the output node combines a projected `bool` instead of the raw `Compilation`. Reference-equality models had been defeating the incremental generator's caching on every keystroke. Guarded by `UnrelatedEdit_LeavesGeneratorOutputsCached`. (#22)
+- **`StopOnFirst` emits its success log line** before its early return. (#22)
+
+---
+
+## Runtime and abstractions
+
+- **`ValidationException.Errors` is genuinely immutable.** All public constructors now snapshot the errors into an array, so a live `List<T>` can no longer be cast back through `IReadOnlyList` and mutated. The `errors` argument is null-guarded. (#22)
+- **`FluentValidationBehavior` null-guards its constructor** — `ArgumentNullException.ThrowIfNull(validators)` instead of a later `NullReferenceException`. (#27)
+- **`FluentValidationBehavior` tolerates FluentValidation's low-level failure API**, which permits a null `PropertyName` / `ErrorMessage` while `ValidationError` annotates both non-null. Both are coalesced. `ConfigureAwait(false)` added to both `next()` awaits. (#23)
+- **`[NotificationExecution]` / `[NotificationError]` are valid on structs.** (#22)
+- **Docs corrected to match the code:** the `Parallel` strategy XML doc described `Task.WhenAll`; the actual mechanism is two-phase `ValueTask` fan-out. Rules 20 and 60 now document the emitted error-path `LogError`, which the code always did and the rules denied. `MediatorDiagnostics.Listener` / `Events` are documented as a **reserved, currently-silent** surface — nothing writes to that `DiagnosticListener`, yet `docs/observability.md` showed a subscription sample and rule 60 pointed consumers at it. (#22, #23)
+
+---
+
+## New diagnostics
+
+Two new build-time warnings. Both replace silent misbehavior with a named, actionable message.
+
+| ID | Severity | Category | Meaning |
+|---|---|---|---|
+| **`MEDL1003`** | Warning | `MediatorLite.Handlers` | Multiple handlers are registered for the same `(request, response)` pair; the dead handlers are named. Dispatch is unchanged — last registration wins. (#23) |
+| **`MEDL1004`** | Warning | `MediatorLite.Handlers` | A handler class is generic or nested inside a generic type and cannot be registered. Previously this emitted non-compiling code. (#24) |
+
+Already shipped in v2.0.5, for reference: **`MEDL1001`** (Error — FluentValidation validators found but the `MediatorLite.FluentValidation` package is not referenced) and **`MEDL1002`** (Warning — an open generic behavior does not match the supported `Behavior<TRequest, TResponse>` shape; message updated in #25).
+
+---
+
+## Repository infrastructure (not shipped in packages)
+
+These fixes affect contributors to this repository only. **No consumer-facing package contains any of this** — listed for completeness, since PRs #22 and #27 are largely infrastructure work.
+
+- **Line endings pinned.** `.claude/**` and `.cursor/**` were committed with CRLF. A CRLF bash script dies on WSL/Linux with `$'\r': command not found`, and because `pre-tool-use.sh` is wired as a `PreToolUse` hook, that failure **denied every agent tool call in the repo**. A new `.gitattributes` sets `* text=auto`, pins `eol=lf` on `*.sh` / `*.csx` and the extension-less `.agents/hooks` scripts, keeps `*.ps1` at CRLF, and marks binaries. 66 files renormalized — line endings only, proven content-free with `git diff --cached --ignore-cr-at-eol`. (#27)
+- **`.csx` hooks stopped aborting.** Every hook exited **134 (SIGABRT)** on Linux/WSL: `Microsoft.Data.Sqlite` pooling closes connections from a `ProcessExit` handler, by which point dotnet-script's native `e_sqlite3` resolver is gone, producing `DllNotFoundException`. A crashing `PreToolUse` hook blocks the command it guards, so this blocked `git commit` outright. Fixed with `Pooling=False` in all three `ContextDb.csx` copies; confirmed by A/B test (pooling on → exit 134, off → exit 0). (#27)
+- **All 7 role agents were non-functional.** Their frontmatter declared invented tool names (`read`, `search`, `edit`, `shell`, `web`), so every spawn was refused with "would be spawned with zero tools" — the entire team documented in `CLAUDE.md` could never run. Corrected to real tool names, scoped per role; read-only agents keep read-only grants. (#27)
+- **Commit and push gates never ran.** `.agents/hooks/pre-commit` and `pre-push` are written for `core.hooksPath`, which nothing set, so `git commit` / `git push` silently bypassed the build, format, lint, and test gates. Now configured, with a documented setup step in `.agents/README.md`. (#27)
+- **Gate scripts no longer deadlock.** They drain child `stdout`/`stderr` concurrently (pipe-deadlock fix) and fail open with a warning when the .NET SDK is missing, instead of crashing and hard-blocking the commit or push. (#22)
+- **Hook SQL injection closed.** `00-save-context.csx` spliced the session id — an external environment variable — into SQL literals and the snapshot filename. Verified end-to-end: a valid id writes a snapshot; `x' OR '1'='1` is refused with no file written. (#24, B5)
+- **CI flake removed.** xUnit parallelization is disabled: fixtures share mutable statics through the open-generic behaviors and raced across test classes. `PublishAsync_WithNoHandlers` now publishes a genuinely handler-less event — it had been exercising a three-handler notification. (#22)
+
+---
+
+## Upgrade guide
+
+1. **Search for `[MediatorGeneration(Skip` in your solution.** Every hit is now inert. Move those types to an assembly the generator does not run on, or accept that they will be registered and dispatched.
+2. **Rebuild and read the warnings.** `MEDL1003` and `MEDL1004` are new and may surface pre-existing problems in your code — a duplicate handler that was always shadowed, or a generic handler that was silently dropped.
+3. **If you catch cancellation from `PublishAsync`:** under `ContinueAndAggregate`, a handler's own `OperationCanceledException` now arrives inside an `AggregateException` alongside its siblings, rather than unwrapped and alone. An unwrapped `OperationCanceledException` now means the publish token itself was cancelled.
+4. **If you target Blazor WebAssembly:** no code change needed. Upgrade and it works.
+5. **No `AddMediatorLite()` or `AddGeneratedHandlers()` call sites change.** The DI surface is untouched.
+
+---
+
+## Verification
+
+- `dotnet build MediatorLite.sln -c Release` — 0 warnings, 0 errors. This repo sets `TreatWarningsAsErrors`, so a warning is a build failure.
+- `dotnet test MediatorLite.sln` — **131/131 passing** on the release commit (`de46f39`).
+- Every generator fix is TDD: the pinning test was written first and confirmed to fail for the documented reason before the fix landed.
+- Selected fixes were confirmed in **both directions** — reverting the #27 generator fix makes its test fail with `found 2`.
+- Generator output is compiled by the driver tests, which assert zero compiler errors — this is what catches emitted `CS0246` / `CS0452` / `CS0111` before a consumer does.
+- `.gitattributes` verified per file with `git check-attr`.
+
+---
+
+## Pull requests in this release
+
+| PR | Title | Author | Status |
+|---|---|---|---|
+| [#22](https://github.com/behl1anmol/MediatorLite/pull/22) | Resolve bug-hunt findings across generator, runtime, tests, and hooks | behl1anmol | **Already released in v2.0.5** |
+| [#23](https://github.com/behl1anmol/MediatorLite/pull/23) | Four dispatch-emission correctness bugs found in bug hunt | behl1anmol | New in v2.1.0 |
+| [#24](https://github.com/behl1anmol/MediatorLite/pull/24) | Bug hunt: fix 7 verified defects (generator dispatch/discovery, parallel cancellation, hook SQL) | behl1anmol | New in v2.1.0 |
+| [#25](https://github.com/behl1anmol/MediatorLite/pull/25) | Support class-constrained open behaviors + generator hardening | behl1anmol | New in v2.1.0 |
+| [#26](https://github.com/behl1anmol/MediatorLite/pull/26) | Fix Blazor/Mono WebAssembly crash: make `Unit.CompletedTask` a computed property | [@SolemnDucc](https://github.com/SolemnDucc) | New in v2.1.0 |
+| [#27](https://github.com/behl1anmol/MediatorLite/pull/27) | Repair line endings, dead agent definitions, crashing hooks, and generator registration dedupe | behl1anmol | New in v2.1.0 |
+
+> **On #22:** its merge commit is contained in tag `v2.0.5` — it merged four minutes before that tag was cut. Its fixes are listed above for a complete picture of the v2.0.4 → v2.1.0 arc, but they are **not new to this release** if you are already on v2.0.5. The one exception worth knowing: #22's `Parallel` + `ContinueAndAggregate` cancellation behavior *was* shipped in v2.0.5 and is **corrected** by #23 in this release. See [Notification cancellation semantics](#notification-cancellation-semantics-corrected).
+
+---
+
+## Architectural notes
+
+Three patterns account for nearly every defect in this release. They are worth naming, because they predict where the next one will be.
+
+**Discovery guards were not shared.** Handlers, behaviors, and validators each grew their own generic-type guard at different times, to different standards — behaviors had `MEDL1002`, validators silently skipped, handlers had nothing at all and pasted unbound type parameters straight into the output. The same hole was then found again in nested-generic form. The fix was a shared containing-type-aware guard, and the lesson is recorded at `.github/Lessons/2026-07-12-generator-discovery-guards-must-be-shared.md`.
+
+**The generator's output is a consumer's build.** Every emission defect here manifests as a compiler error in a file the consumer never wrote and cannot fix. That asymmetry is why the correct response to an unsupported shape is always *diagnostic plus skip*, never *emit and hope* — and why the driver tests now compile the generated output and assert zero errors rather than merely inspecting it as text.
+
+**Compile-time strategy resolution has no runtime escape hatch.** Notification strategies are inlined into the generated `Publish_*` methods, so a wrong compile-time decision — an attribute read from the wrong assembly, a same-named attribute from a foreign namespace, an error strategy that drops faults — is unfixable at runtime by the consumer. Several fixes here (#23's symbol-side attribute reads, namespace-qualified matching, the `ContinueAndAggregate` fault semantics) are all instances of getting that one-shot decision right.
+
+---
+
+## Credits
+
+Thanks to **[@SolemnDucc](https://github.com/SolemnDucc)** for the Blazor WebAssembly diagnosis in #26 — a native Mono assertion, load-order dependent and invisible on CoreCLR, tracked to a single self-referential static field and fixed in one line, with a standalone reproduction repo. That is an exemplary bug report.


### PR DESCRIPTION
## Summary

Two new documents under `docs/releases/`, covering the closed bug-fix PRs #22–#27. **Docs only — no source, test, or build changes.**

- `docs/releases/v2.1.0.md` — the release note, ready to paste into the GitHub release body.
- `docs/releases/v2.1.0-open-findings.md` — three items observed during verification, for maintainer review.

## Verified, not paraphrased

Claims were re-derived from the code on `de46f39` rather than trusted from PR bodies. Confirmed: every asserted line reference (`HandlerDiscoveryGenerator.cs:845`, `Attributes.cs:228`, `Unit.cs:29`), all four diagnostic IDs and severities against `AnalyzerReleases.Unshipped.md`, the generated cancellation catch clause, every cited test name, and `dotnet test MediatorLite.sln` → **131/131 passing**.

## Two findings that shaped the scope

**PR #22 already shipped.** Its merge commit `9fa7cdd` is contained in tag `v2.0.5` — merged 09:20:33 UTC, tagged 09:24:26 UTC the same day. It is documented as already-released rather than as new work. The wrinkle worth knowing: #22's `Parallel` + `ContinueAndAggregate` cancellation behavior *did* ship in v2.0.5 and is **corrected** by #23 in this release, so v2.0.5 consumers see a real behavior change. The note calls this out explicitly.

**Version is v2.1.0, not a patch.** PR #24 made `[MediatorGeneration(Skip = true)]` inert — verified: no code under `src/` reads it anymore. Rule 90 §3 classifies attribute-semantics changes as breaking, and the repo already shipped an ADR treating it as such.

## Open findings (no code changed)

1. **Analyzer release tracking never advances** — `MEDL1001`/`MEDL1002` shipped in v2.0.5 but still sit in `Unshipped.md`; `Shipped.md` has zero rules. The RS2008 breaking-change protection is inert as a result. Suggest a `/release-workflow` step.
2. **`Microsoft.Extensions.*` 9.0.0 on a net10.0 package** — analyzed; **recommending no change**. The low floor is defensible for a library. Suggest a comment documenting the intent.
3. **Class-constrained open behavior can register nothing silently** — PR #25's own residual note. Harmless in effect (the constraint makes it inapplicable), but the author believes it runs. Suggest a follow-up `MEDL1005`.

## Notes for the reviewer

- Version number and release date are the maintainer's call at tag time; the doc names v2.1.0 per the decision recorded above.
- Publishing is tag-driven (`publish.yml` extracts the version from `refs/tags/v*`), so merging this changes nothing about the release mechanics.
- Anchor links in both docs were checked programmatically — no broken internal links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)