### PR TITLE
fix: resolve v2.1.0 open findings (analyzer ledger, deps, MEDL1005)

### DIFF
--- a/.claude/commands/release-workflow.md
+++ b/.claude/commands/release-workflow.md
@@ -38,7 +38,9 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
    Select-String -Path src\**\*.csproj -Pattern '<Version>' -SimpleMatch
    ```
 
-3. **Update the changelog (if present).** If `CHANGELOG.md` exists at the repo root, prepend a new section with the version, date, and a bullet list grouped by `Added`, `Changed`, `Fixed`, `Breaking`. If it does not exist, skip — the GitHub Release is auto-generated from commits by the publish workflow:
+3. **Advance the analyzer release ledger.** Before tagging, move every diagnostic rule that ships in this version from `src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md` into a `## Release X.Y.Z` section of `src/MediatorLite.SourceGeneration/AnalyzerReleases.Shipped.md` (create the section if it does not exist), then delete those rows from `Unshipped.md`. The RS2008 release-tracking analyzer reads the Shipped ledger to detect a *later* breaking change to a rule — a severity downgrade, a category change, a removal — so leaving rules permanently in `Unshipped.md` makes that protection inert. A rule declared in the generator but present in neither file fails the RS2008 build gate, so rebuild after moving and confirm the build stays clean.
+
+4. **Update the changelog (if present).** If `CHANGELOG.md` exists at the repo root, prepend a new section with the version, date, and a bullet list grouped by `Added`, `Changed`, `Fixed`, `Breaking`. If it does not exist, skip — the GitHub Release is auto-generated from commits by the publish workflow:
 
    ```94:100:.github/workflows/publish.yml
        - name: Create GitHub Release
@@ -50,7 +52,7 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
            tag_name: ${{ steps.release_tag.outputs.TAG_NAME }}
    ```
 
-4. **Verify benchmarks locally** on the release candidate commit:
+5. **Verify benchmarks locally** on the release candidate commit:
 
    ```powershell
    dotnet run -c Release --project tests/MediatorLite.Benchmarks -- --filter '*' --exporters json markdown --memory
@@ -58,15 +60,15 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
 
    Compare the summary to the previous release's snapshot (available in [docs/benchmarks.md](docs/benchmarks.md) or the prior release's artifact). No regression > 10% mean time / > 5% allocations without a documented reason.
 
-5. **Open a release PR** titled `chore(release): vX.Y.Z`. Required content:
+6. **Open a release PR** titled `chore(release): vX.Y.Z`. Required content:
    - Version bump diff on the three `.csproj`s.
    - Changelog delta (if applicable).
    - Benchmark comment from CI attached to the PR.
    - Link to any lessons or memories shipped in this release.
 
-6. **Merge to `main`** once the CI workflow is green and `code-reviewer` has approved.
+7. **Merge to `main`** once the CI workflow is green and `code-reviewer` has approved.
 
-7. **Create and push the tag** from the merge commit on `main`. The publish workflow keys off tags of the form `v*.*.*`:
+8. **Create and push the tag** from the merge commit on `main`. The publish workflow keys off tags of the form `v*.*.*`:
 
    ```6:10:.github/workflows/publish.yml
    on:
@@ -85,7 +87,7 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
    git push origin v1.2.3
    ```
 
-8. **Watch the publish workflow**. It performs, in order:
+9. **Watch the publish workflow**. It performs, in order:
    - Restore → build with `/p:Version=<X.Y.Z>` → run the full test suite.
    - `dotnet pack` on each of the three projects into `./artifacts/*.nupkg`.
    - Upload the artifact (`nuget-packages`).
@@ -94,7 +96,7 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
 
    Expected: workflow exit code `0`, three packages visible on nuget.org at the new version within a few minutes.
 
-9. **Post-publish verification** (smoke test from a clean working directory):
+10. **Post-publish verification** (smoke test from a clean working directory):
 
    ```powershell
    dotnet new console -n ReleaseSmoke -o /tmp/ReleaseSmoke

--- a/.claude/instructions/release-workflow.md
+++ b/.claude/instructions/release-workflow.md
@@ -38,7 +38,9 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
    Select-String -Path src\**\*.csproj -Pattern '<Version>' -SimpleMatch
    ```
 
-3. **Update the changelog (if present).** If `CHANGELOG.md` exists at the repo root, prepend a new section with the version, date, and a bullet list grouped by `Added`, `Changed`, `Fixed`, `Breaking`. If it does not exist, skip — the GitHub Release is auto-generated from commits by the publish workflow:
+3. **Advance the analyzer release ledger.** Before tagging, move every diagnostic rule that ships in this version from `src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md` into a `## Release X.Y.Z` section of `src/MediatorLite.SourceGeneration/AnalyzerReleases.Shipped.md` (create the section if it does not exist), then delete those rows from `Unshipped.md`. The RS2008 release-tracking analyzer reads the Shipped ledger to detect a *later* breaking change to a rule — a severity downgrade, a category change, a removal — so leaving rules permanently in `Unshipped.md` makes that protection inert. A rule declared in the generator but present in neither file fails the RS2008 build gate, so rebuild after moving and confirm the build stays clean.
+
+4. **Update the changelog (if present).** If `CHANGELOG.md` exists at the repo root, prepend a new section with the version, date, and a bullet list grouped by `Added`, `Changed`, `Fixed`, `Breaking`. If it does not exist, skip — the GitHub Release is auto-generated from commits by the publish workflow:
 
    ```94:100:.github/workflows/publish.yml
        - name: Create GitHub Release
@@ -50,7 +52,7 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
            tag_name: ${{ steps.release_tag.outputs.TAG_NAME }}
    ```
 
-4. **Verify benchmarks locally** on the release candidate commit:
+5. **Verify benchmarks locally** on the release candidate commit:
 
    ```powershell
    dotnet run -c Release --project tests/MediatorLite.Benchmarks -- --filter '*' --exporters json markdown --memory
@@ -58,15 +60,15 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
 
    Compare the summary to the previous release's snapshot (available in [docs/benchmarks.md](docs/benchmarks.md) or the prior release's artifact). No regression > 10% mean time / > 5% allocations without a documented reason.
 
-5. **Open a release PR** titled `chore(release): vX.Y.Z`. Required content:
+6. **Open a release PR** titled `chore(release): vX.Y.Z`. Required content:
    - Version bump diff on the three `.csproj`s.
    - Changelog delta (if applicable).
    - Benchmark comment from CI attached to the PR.
    - Link to any lessons or memories shipped in this release.
 
-6. **Merge to `main`** once the CI workflow is green and `code-reviewer` has approved.
+7. **Merge to `main`** once the CI workflow is green and `code-reviewer` has approved.
 
-7. **Create and push the tag** from the merge commit on `main`. The publish workflow keys off tags of the form `v*.*.*`:
+8. **Create and push the tag** from the merge commit on `main`. The publish workflow keys off tags of the form `v*.*.*`:
 
    ```6:10:.github/workflows/publish.yml
    on:
@@ -85,7 +87,7 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
    git push origin v1.2.3
    ```
 
-8. **Watch the publish workflow**. It performs, in order:
+9. **Watch the publish workflow**. It performs, in order:
    - Restore → build with `/p:Version=<X.Y.Z>` → run the full test suite.
    - `dotnet pack` on each of the three projects into `./artifacts/*.nupkg`.
    - Upload the artifact (`nuget-packages`).
@@ -94,7 +96,7 @@ Cut a new MediatorLite release: bump semver on the three shipped packages, updat
 
    Expected: workflow exit code `0`, three packages visible on nuget.org at the new version within a few minutes.
 
-9. **Post-publish verification** (smoke test from a clean working directory):
+10. **Post-publish verification** (smoke test from a clean working directory):
 
    ```powershell
    dotnet new console -n ReleaseSmoke -o /tmp/ReleaseSmoke

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,6 +19,17 @@ search:
 # Navigation
 nav_enabled: true
 
+# Front-matter defaults — auto-apply the doc layout to every file under
+# docs/releases/ so a new release note renders correctly with zero config. Each
+# note nests under the "Releases" nav section via its own `parent: Releases` +
+# `title:` front matter (two lines; see docs/releases/index.md for the template).
+defaults:
+  - scope:
+      path: "releases"
+      type: "pages"
+    values:
+      layout: "default"
+
 # Footer
 footer_content: >
   Copyright &copy; 2026 <a href="https://github.com/behl1anmol">behl1anmol</a>.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,34 @@
+---
+title: Releases
+nav_order: 9
+has_children: true
+---
+
+# Releases
+
+Release notes for each published MediatorLite version. Pick a version from the
+navigation on the left, or the list below.
+
+{% assign release_pages = site.pages | where_exp: "p", "p.parent == 'Releases'" | sort: "title" %}
+<ul>
+{% for p in release_pages %}
+  <li><a href="{{ p.url | relative_url }}">{{ p.title }}</a></li>
+{% endfor %}
+</ul>
+
+---
+
+## Adding a new release note
+
+1. Create `docs/releases/<version>.md`.
+2. Begin the file with this front matter, then write the notes below it:
+
+   ```yaml
+   ---
+   title: "vX.Y.Z"
+   parent: Releases
+   ---
+   ```
+
+The page auto-joins the **Releases** section in the left navigation and the list
+above — no other file needs editing.

--- a/docs/releases/v2.1.0-open-findings.md
+++ b/docs/releases/v2.1.0-open-findings.md
@@ -1,3 +1,8 @@
+---
+title: "v2.1.0 — Open findings"
+parent: Releases
+---
+
 # Open findings — observed while preparing the v2.1.0 release notes
 
 **Status: for your review. No code was changed.**

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -160,12 +160,13 @@ Types that *should* have been discovered but were silently skipped, and types th
 
 ## New diagnostics
 
-Two new build-time warnings. Both replace silent misbehavior with a named, actionable message.
+Three new build-time warnings. Each replaces silent misbehavior with a named, actionable message.
 
 | ID | Severity | Category | Meaning |
 |---|---|---|---|
 | **`MEDL1003`** | Warning | `MediatorLite.Handlers` | Multiple handlers are registered for the same `(request, response)` pair; the dead handlers are named. Dispatch is unchanged — last registration wins. (#23) |
 | **`MEDL1004`** | Warning | `MediatorLite.Handlers` | A handler class is generic or nested inside a generic type and cannot be registered. Previously this emitted non-compiling code. (#24) |
+| **`MEDL1005`** | Warning | `MediatorLite.Behaviors` | A discovered open pipeline behavior expanded to zero registrations — it matched no request and will never run (e.g. a `where TRequest : class` behavior when every discovered request is a value type). Previously it was skipped silently. |
 
 Already shipped in v2.0.5, for reference: **`MEDL1001`** (Error — FluentValidation validators found but the `MediatorLite.FluentValidation` package is not referenced) and **`MEDL1002`** (Warning — an open generic behavior does not match the supported `Behavior<TRequest, TResponse>` shape; message updated in #25).
 

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,3 +1,8 @@
+---
+title: "v2.1.0"
+parent: Releases
+---
+
 # MediatorLite v2.1.0
 
 **Stability and correctness release.** Six merged pull requests (#22–#27), all bug fixes. No new features, no new public API.

--- a/src/MediatorLite.SourceGeneration/AnalyzerReleases.Shipped.md
+++ b/src/MediatorLite.SourceGeneration/AnalyzerReleases.Shipped.md
@@ -1,2 +1,21 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 2.0.5
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MEDL1001 | MediatorLite.Validation | Error | FluentValidation validators were found but the MediatorLite.FluentValidation package is not referenced.
+MEDL1002 | MediatorLite.Behaviors | Warning | An open generic pipeline behavior does not match the supported Behavior&lt;TRequest, TResponse&gt; shape and was not registered.
+
+## Release 2.1.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MEDL1003 | MediatorLite.Handlers | Warning | Multiple handlers are registered for the same (request, response) pair; only the last registration is invoked at dispatch time.
+MEDL1004 | MediatorLite.Handlers | Warning | A handler class is generic or nested inside a generic type and cannot be registered by the source generator.
+MEDL1005 | MediatorLite.Behaviors | Warning | An open generic pipeline behavior expanded to zero registrations (a class-constrained open behavior when every discovered request is a value type) and was not registered.

--- a/src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md
+++ b/src/MediatorLite.SourceGeneration/AnalyzerReleases.Unshipped.md
@@ -1,11 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-MEDL1001 | MediatorLite.Validation | Error | FluentValidation validators were found but the MediatorLite.FluentValidation package is not referenced.
-MEDL1002 | MediatorLite.Behaviors | Warning | An open generic pipeline behavior does not match the supported Behavior<TRequest, TResponse> shape and was not registered.
-MEDL1003 | MediatorLite.Handlers | Warning | Multiple handlers are registered for the same (request, response) pair; only the last registration is invoked at dispatch time.
-MEDL1004 | MediatorLite.Handlers | Warning | A handler class is generic or nested inside a generic type and cannot be registered by the source generator.

--- a/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
+++ b/src/MediatorLite.SourceGeneration/HandlerDiscoveryGenerator.cs
@@ -92,6 +92,28 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Reported when a discovered open generic pipeline behavior expands to zero closed
+    /// registrations — every discovered request was filtered out during expansion. The only
+    /// such filter today is the reference-type guard: an open behavior constrained
+    /// <c>where TRequest : class</c> cannot be closed over a value-type request (CS0452), so if
+    /// every request in the compilation is a value type the behavior applies to nothing. The
+    /// build is clean and no other diagnostic fires, so the author can wrongly believe the
+    /// behavior runs (the same silent-skip failure mode MEDL1002/MEDL1004 exist to prevent).
+    /// Surface it here instead of registering nothing in silence.
+    /// </summary>
+    private static readonly DiagnosticDescriptor OpenBehaviorRegisteredAgainstNoRequest = new(
+        id: "MEDL1005",
+        title: "Open pipeline behavior is registered against no request",
+        messageFormat: "Open pipeline behavior '{0}' matched no request type in this compilation, so it "
+            + "was not registered and will never run. This happens when a behavior constrained "
+            + "'where TRequest : class' is the only shape but every discovered request is a value type "
+            + "(a value type cannot satisfy the class constraint). Make at least one target request a "
+            + "reference type, or close the behavior over a concrete request type.",
+        category: "MediatorLite.Behaviors",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Find all class declarations that might be handlers
@@ -730,7 +752,16 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                 handlerNames[handlerNames.Count - 1]));
         }
 
-        var expandedBehaviors = ExpandBehaviors(validBehaviors, validHandlers);
+        var expandedBehaviors = ExpandBehaviors(
+            validBehaviors, validHandlers, out var openBehaviorsWithoutExpansion);
+
+        // A discovered open behavior that expanded to nothing registers against no request and
+        // will never run — surface it (MEDL1005) rather than let the author believe it is active.
+        foreach (var behaviorName in openBehaviorsWithoutExpansion)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                OpenBehaviorRegisteredAgainstNoRequest, Location.None, StripGlobalPrefix(behaviorName)));
+        }
 
         // Determine which request types need validation
         var requestTypesWithValidation = DetermineValidationTargets(validHandlers, validValidators);
@@ -816,9 +847,11 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
     /// </summary>
     private static List<ExpandedBehaviorInfo> ExpandBehaviors(
         List<BehaviorInfo> behaviors,
-        List<HandlerInfo> handlers)
+        List<HandlerInfo> handlers,
+        out List<string> openBehaviorsWithoutExpansion)
     {
         var expanded = new List<ExpandedBehaviorInfo>();
+        openBehaviorsWithoutExpansion = new List<string>();
 
         var requestResponsePairs = handlers
             .SelectMany(h => h.RequestHandlers.Select(r => (r.RequestType, r.ResponseType!)))
@@ -836,10 +869,18 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
 
         foreach (var behavior in behaviors)
         {
+            // Track whether this behavior contributes an expandable open interface, and how many
+            // registrations (open OR closed) it produced in total, so a behavior that matches no
+            // request at all can be surfaced via MEDL1005 instead of vanishing silently.
+            var hasOpenInterface = false;
+            var registrationCount = 0;
+
             foreach (var behaviorInterface in behavior.BehaviorInterfaces)
             {
                 if (behaviorInterface.IsOpenGeneric && behavior.IsOpenGeneric)
                 {
+                    hasOpenInterface = true;
+
                     foreach (var (requestType, responseType) in requestResponsePairs)
                     {
                         if (behavior.RequestMustBeReferenceType && valueTypeRequests.Contains(requestType))
@@ -861,6 +902,7 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                             ResponseType: responseType,
                             InterfaceType: closedInterfaceType,
                             Order: behavior.Order));
+                        registrationCount++;
                     }
                 }
                 else if (!behaviorInterface.IsOpenGeneric)
@@ -877,7 +919,29 @@ public sealed class HandlerDiscoveryGenerator : IIncrementalGenerator
                         ResponseType: behaviorInterface.ResponseType!,
                         InterfaceType: behaviorInterface.InterfaceType,
                         Order: behavior.Order));
+                    registrationCount++;
                 }
+            }
+
+            // The behavior declared an expandable open interface, requests exist to expand over,
+            // yet it registered nothing — every candidate pair was filtered out. The only filter
+            // that can empty a supported open behavior today is the reference-type guard, so this
+            // is precisely the `where TRequest : class` behavior over an all-value-type request set;
+            // the emitted message names that cause. Guards:
+            //  - requestResponsePairs.Count > 0 keeps the cause accurate: a compilation with no
+            //    request handlers at all (e.g. notification-only) is out of scope — the behavior has
+            //    nothing to apply to for a reason MEDL1005's message does not describe, so skip it.
+            //  - registrationCount counts BOTH branches, so a behavior that also registers a closed
+            //    interface is never falsely flagged.
+            //  - !HasUnsupportedOpenShape skips behaviors already reported via MEDL1002 (a generic
+            //    class can carry a supported open interface AND trip the unsupported-shape flag via a
+            //    closed-on-generic interface), so MEDL1005 and MEDL1002 never double-fire.
+            if (hasOpenInterface
+                && registrationCount == 0
+                && requestResponsePairs.Count > 0
+                && !behavior.HasUnsupportedOpenShape)
+            {
+                openBehaviorsWithoutExpansion.Add(behavior.ClassName);
             }
         }
 

--- a/src/MediatorLite/MediatorLite.csproj
+++ b/src/MediatorLite/MediatorLite.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
+++ b/tests/MediatorLite.Tests/UnitTests/SourceGeneratorDriverTests.cs
@@ -899,6 +899,54 @@ public class SourceGeneratorDriverTests
             "the class-constrained behavior must expand over the reference-type request");
         generated.Should().NotContain("RefOnlyBehavior<global::DriverTests.StructQuery, int>",
             "a `where TRequest : class` behavior must not be expanded over a value-type request");
+        runResult.Diagnostics.Should().NotContain(d => d.Id == "MEDL1005",
+            "the behavior still expands over the reference-type PingQuery, so it registers against something");
+
+        AssertGeneratedOutputCompiles(updatedCompilation);
+    }
+
+    [Fact]
+    public void ClassConstrainedOpenBehavior_OverOnlyValueTypeRequests_ReportsMedl1005_AndRegistersNothing()
+    {
+        // A `where TRequest : class` open behavior is a supported shape, but a value-type request
+        // cannot satisfy the class constraint, so when EVERY discovered request is a value type the
+        // behavior expands to zero closed registrations — it applies to nothing and never runs.
+        // Without a diagnostic the author has no signal (clean build, no MEDL1002 since the shape is
+        // supported), so this must surface MEDL1005. HandlerSource is deliberately omitted so the
+        // struct is the only request; the struct handler keeps validHandlers non-empty (otherwise
+        // the generator early-returns an empty registration before expansion ever runs).
+        const string source = """
+            using MediatorLite;
+
+            namespace DriverTests;
+
+            public readonly record struct StructQuery(int Value) : IRequest<int>;
+
+            public sealed class StructQueryHandler : IRequestHandler<StructQuery, int>
+            {
+                public ValueTask<int> HandleAsync(StructQuery request, CancellationToken cancellationToken = default)
+                    => ValueTask.FromResult(request.Value);
+            }
+
+            public sealed class RefOnlyBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+                where TRequest : class, IRequest<TResponse>
+            {
+                public ValueTask<TResponse> HandleAsync(
+                    TRequest request,
+                    RequestHandlerDelegate<TResponse> next,
+                    CancellationToken cancellationToken = default)
+                    => next();
+            }
+            """;
+
+        var (runResult, updatedCompilation) = RunGeneratorAndUpdateCompilation(source);
+
+        runResult.Diagnostics.Should().ContainSingle(d => d.Id == "MEDL1005")
+            .Which.GetMessage().Should().Contain("RefOnlyBehavior");
+
+        var generated = string.Join("\n", runResult.GeneratedTrees.Select(t => t.ToString()));
+        generated.Should().NotContain("RefOnlyBehavior<",
+            "an open behavior that matched no request must register nothing, not emit a closed type");
 
         AssertGeneratedOutputCompiles(updatedCompilation);
     }


### PR DESCRIPTION
Closes the three items in `docs/releases/v2.1.0-open-findings.md` before shipping v2.1.0. Two were release-process/hygiene gaps; one adds a diagnostic for a silent-skip case.

## Finding 1 — Analyzer release tracking advanced to `Shipped.md`
`AnalyzerReleases.Shipped.md` had zero rules while all four `MEDL100x` sat in `Unshipped.md`, even though `MEDL1001`/`MEDL1002` already shipped in `v2.0.5`. The RS2008 release-tracking analyzer reads the Shipped ledger to detect later breaking changes to a rule (severity/category change, removal); leaving rules permanently unshipped made that protection inert.
- `Shipped.md`: `## Release 2.0.5` (MEDL1001, MEDL1002) and `## Release 2.1.0` (MEDL1003, MEDL1004, MEDL1005).
- `Unshipped.md`: stripped to header-only.
- `release-workflow.md` (both synced copies): new "advance the ledger" step before tagging.

The `2.0.5` attribution is corroborated by the existing release notes (`docs/releases/v2.1.0.md`), which already state MEDL1001/1002 shipped in v2.0.5.

## Finding 2 — Dependency version coherence
`Microsoft.Extensions.{DependencyInjection,Logging}.Abstractions` bumped `9.0.0` → `10.0.0` to match the `net10.0` TFM. NuGet already unified these to 10.x for real consumers; this removes the downgrade-warning surface for consumers who pin.

## Finding 3 — New `MEDL1005` warning
A `where TRequest : class` open pipeline behavior is a supported shape, but value-type requests are filtered at expansion time (to avoid emitting a CS0452-violating closed type). If **every** discovered request is a value type, the behavior expands to nothing — registers nothing, runs never, warns never. Same silent-skip failure mode `MEDL1003`/`MEDL1004` exist to close.

- Descriptor + detection in `ExpandBehaviors`, reported in `Execute`, mirroring the `MEDL1002`/`MEDL1004` pattern.
- Fire condition: `hasOpenInterface && registrationCount == 0 && requestResponsePairs.Count > 0 && !behavior.HasUnsupportedOpenShape`.
  - `registrationCount` counts **both** open and closed branches → a behavior that registers a closed interface is never falsely flagged.
  - `requestResponsePairs.Count > 0` scopes the fire to the case the message describes (all-value-type request set), so a compilation with no request handlers at all does not misfire.
  - `!HasUnsupportedOpenShape` prevents an `MEDL1002`/`MEDL1005` double-fire on a generic class carrying both a supported open interface and an unsupported closed-on-generic interface.
- Tests: positive all-value-type case + a regression assertion on the mixed value/reference case. Diagnostics catalog row added to `docs/releases/v2.1.0.md`.

## Verification
- `dotnet build` — clean, **0 warnings** (RS2008 ledger consistent with the descriptors; `MEDL1005` properly tracked).
- `dotnet test` — **132/132** pass (was 131; +1 new MEDL1005 test).
- Deps restore at `10.0.0` with no downgrade warnings.
- No dispatch-invariant or public-API change; `*Count` registration semantics unaffected.

## Notes for the reviewer
- Two independent review passes were run; a false-positive/double-fire edge was found and closed by the guards above, then re-verified.
- `tests/**` and `benchmarks/**` still reference the *non-abstractions* `Microsoft.Extensions.*` at 9.0.0 — internal, not shipped, and NuGet unifies transitively; left out of scope.
- No commit/tag of the release itself here — that remains the `/release-workflow` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)